### PR TITLE
Allow additional items in the schema dictionary

### DIFF
--- a/jsonschema.py
+++ b/jsonschema.py
@@ -328,14 +328,8 @@ class Validator(object):
 
             validator = getattr(self, u"validate_%s" % (k.lstrip("$"),), None)
 
-            if validator is None:
-                self.schema_error(
-                    self._unknown_property,
-                    u"%r is not a known schema property" % (k,)
-                )
-                return
-
-            validator(v, instance, schema)
+            if validator is not None:
+                validator(v, instance, schema)
 
     def validate(self, instance, schema):
         """


### PR DESCRIPTION
In our application, we want to be able to attach additional properties to our schemas that helps our system convert to/from a legacy file format.

We're doing things like this (a schema snippet):

```
{
    title: "Our schema",
    type: "string",
    legacy_name: "OLD_NAME_1"
}
```

AFAICT, the JSON schema spec doesn't exclude us from attaching extra properties to a schema like this.  In fact, the JSON Schema Schema doesn't set `additionalProperties` for a schema, and the default behavior is to allow them.

This simple patch simply doesn't raise an exception when there are extra elements attached to a schema.
