### PR TITLE
Make it python 2.5 compatible

### DIFF
--- a/catch_warnings25.py
+++ b/catch_warnings25.py
@@ -1,0 +1,88 @@
+"""Back port warnings.check_warnings for python2.5"""
+
+# Note: function level imports should *not* be used
+# in this module as it may cause import lock deadlock.
+# See bug 683658.
+import sys
+
+
+class WarningMessage(object):
+
+    """Holds the result of a single showwarning() call."""
+
+    _WARNING_DETAILS = ("message", "category", "filename", "lineno", "file",
+                        "line")
+
+    def __init__(self, message, category, filename, lineno, file=None,
+                    line=None):
+        local_values = locals()
+        for attr in self._WARNING_DETAILS:
+            setattr(self, attr, local_values[attr])
+        self._category_name = category.__name__ if category else None
+
+    def __str__(self):
+        return ("{message : %r, category : %r, filename : %r, lineno : %s, "
+                    "line : %r}" % (self.message, self._category_name,
+                                    self.filename, self.lineno, self.line))
+
+
+class catch_warnings(object):
+
+    """A context manager that copies and restores the warnings filter upon
+    exiting the context.
+
+    The 'record' argument specifies whether warnings should be captured by a
+    custom implementation of warnings.showwarning() and be appended to a list
+    returned by the context manager. Otherwise None is returned by the context
+    manager. The objects appended to the list are arguments whose attributes
+    mirror the arguments to showwarning().
+
+    The 'module' argument is to specify an alternative module to the module
+    named 'warnings' and imported under that name. This argument is only useful
+    when testing the warnings module itself.
+
+    """
+
+    def __init__(self, record=False, module=None):
+        """Specify whether to record warnings and if an alternative module
+        should be used other than sys.modules['warnings'].
+
+        For compatibility with Python 3.0, please consider all arguments to be
+        keyword-only.
+
+        """
+        self._record = record
+        self._module = sys.modules['warnings'] if module is None else module
+        self._entered = False
+
+    def __repr__(self):
+        args = []
+        if self._record:
+            args.append("record=True")
+        if self._module is not sys.modules['warnings']:
+            args.append("module=%r" % self._module)
+        name = type(self).__name__
+        return "%s(%s)" % (name, ", ".join(args))
+
+    def __enter__(self):
+        if self._entered:
+            raise RuntimeError("Cannot enter %r twice" % self)
+        self._entered = True
+        self._filters = self._module.filters
+        self._module.filters = self._filters[:]
+        self._showwarning = self._module.showwarning
+        if self._record:
+            log = []
+
+            def showwarning(*args, **kwargs):
+                log.append(WarningMessage(*args, **kwargs))
+            self._module.showwarning = showwarning
+            return log
+        else:
+            return None
+
+    def __exit__(self, *exc_info):
+        if not self._entered:
+            raise RuntimeError("Cannot exit %r without entering first" % self)
+        self._module.filters = self._filters
+        self._module.showwarning = self._showwarning

--- a/jsonschema.py
+++ b/jsonschema.py
@@ -1,3 +1,6 @@
+from __future__ import with_statement
+
+
 """
 An implementation of JSON Schema for Python
 
@@ -9,8 +12,6 @@ The :class:`Validator` class generally attempts to be as strict as possible
 under the JSON Schema specification. See its docstring for details.
 
 """
-
-from __future__ import division, unicode_literals
 
 import collections
 import itertools
@@ -27,7 +28,7 @@ if PY3:
     iteritems = operator.methodcaller("items")
 else:
     from itertools import izip as zip
-    iteritems = operator.methodcaller("iteritems")
+    iteritems = lambda x: x.iteritems()
 
 
 def _uniq(container):
@@ -281,7 +282,11 @@ class Validator(object):
 
         """
 
-        error = next(self.iter_errors(instance, schema, meta_validate), None)
+        #error = next(self.iter_errors(instance, schema, meta_validate), None)
+        try:
+            error = self.iter_errors(instance, schema, meta_validate).next()
+        except StopIteration:
+            error = None
         return error is None
 
     def iter_errors(self, instance, schema, meta_validate=True):

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import with_statement
+
 from distutils.core import setup
 
 from jsonschema import __version__

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
-from __future__ import unicode_literals
+from __future__ import with_statement
+
 from decimal import Decimal
 from functools import wraps
 import sys
@@ -15,6 +16,12 @@ from jsonschema import (
     iteritems, validate
 )
 
+
+try:
+    warnings.catch_warnings
+except AttributeError:
+    import catch_warnings25
+    warnings.catch_warnings = catch_warnings25.catch_warnings
 
 if PY3:
     basestring = unicode = str
@@ -576,18 +583,11 @@ class TestValidate(ParameterizedTestCase, unittest.TestCase):
             "minItems" : 3
         }
 
-        if PY3:
-            errors = sorted([
-                "'array' is disallowed for [1, 2]",
-                "[1, 2] is too short",
-                "[1, 2] is not one of [['a', 'b', 'c'], ['d', 'e', 'f']]",
-            ])
-        else:
-            errors = sorted([
-                "u'array' is disallowed for [1, 2]",
-                "[1, 2] is too short",
-                "[1, 2] is not one of [[u'a', u'b', u'c'], [u'd', u'e', u'f']]",
-            ])
+        errors = sorted([
+            "'array' is disallowed for [1, 2]",
+            "[1, 2] is too short",
+            "[1, 2] is not one of [['a', 'b', 'c'], ['d', 'e', 'f']]",
+        ])
 
         self.assertEqual(
             sorted(str(e) for e in Validator().iter_errors(instance, schema)),


### PR DESCRIPTION
These changes make it python2.5 compatible.

Unit tested (nosetests) with python2.5, 2.6 and 2.7.

Removed unicode_literals - since the code contains plain strings and not unicode.  Also, py2.5 does not have unicode_literals.

Removed unused imports - e.g. division.
