### PR TITLE
Json ref decoding w/ tests

### DIFF
--- a/jsonschema.py
+++ b/jsonschema.py
@@ -557,6 +557,7 @@ def resolve_local_ref(schema, ref):
 
     parts = ref.lstrip("#/").split("/")
 
+    parts = map(unquote, parts)
     parts = [part.replace('~1', '/').replace('~0', '~') for part in parts]
 
     try:

--- a/tests.py
+++ b/tests.py
@@ -603,15 +603,18 @@ class TestValidate(ParameterizedTestCase, TestCase):
     ))
 
     escaped_pointer_ref = parametrized(
-        ("slash", "invalid", {"shash": "aoeu"}),
-        ("tilda", "invalid", {"tilda": "aoeu"})
+        ("slash", "invalid", {"slash": "aoeu"}),
+        ("tilda", "invalid", {"tilda": "aoeu"}),
+        ("percent", "invalid", {"percent": "aoeu"})
     )(validation_test(
         schema= {
             "tilda~field": {"type": "integer"},
             "slash/field": {"type": "integer"},
+            "percent%field": {"type": "integer"},
             "properties": {
                 "tilda": {"$ref": "#/tilda~0field"},
-                "slash": {"$ref": "#/slash~1field"}
+                "slash": {"$ref": "#/slash~1field"},
+                "percent": {"$ref": "#/percent%25field"}
             }
         }
     ))


### PR DESCRIPTION
Added the json pointer and percent decoding back into ref support along with tests. refs #37
