### PR TITLE
Unknown type not being treated as 'any'

### DIFF
--- a/jsonschema.py
+++ b/jsonschema.py
@@ -125,7 +125,6 @@ class Draft3Validator(object):
 
         self._types = dict(self.DEFAULT_TYPES)
         self._types.update(types)
-        self._types["any"] = tuple(self._types.values())
 
         if resolver is None:
             resolver = RefResolver()
@@ -139,9 +138,11 @@ class Draft3Validator(object):
 
         """
 
-        if type not in self._types:
-            raise UnknownType(type)
-        type = self._types[type]
+        type = self._types.get(type, "any")
+
+        # If type is "any", then this will always succeed
+        if type == "any":
+            return True
 
         # bool inherits from int, so ensure bools aren't reported as integers
         if isinstance(instance, bool):

--- a/tests.py
+++ b/tests.py
@@ -366,9 +366,8 @@ class TestDraft3Validator(TestCase):
         self.assertTrue(self.validator.is_type(True, "boolean"))
         self.assertTrue(self.validator.is_type(True, "any"))
 
-    def test_is_type_raises_exception_for_unknown_type(self):
-        with self.assertRaises(UnknownType):
-            self.validator.is_type("foo", object())
+    def test_is_type_is_true_for_unknown_type(self):
+        self.assertTrue(self.validator.is_type("foo", "some_random_type"))
 
 
 class TestRefResolver(TestCase):


### PR DESCRIPTION
According to draft 3, if type of a value is not in the list of specified types then any type is valid: http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1

Useful for BSON-based databases like MongoDB which have some extra types like ObjectId.
