### PR TITLE
Correct license (MIT/X => MIT).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     author_email="Julian@GrayVines.com",
     classifiers=classifiers,
     description="An implementation of JSON Schema validation for Python",
-    license="MIT/X",
+    license="MIT",
     long_description=long_description,
     url="http://github.com/Julian/jsonschema",
 )


### PR DESCRIPTION
The license (file) you are using seems to be MIT and not MIT/X (as [Wikipedia](http://en.wikipedia.org/wiki/MIT_License) states - referring to the distinguishing sentence). After some [research](http://www.techopedia.com/definition/3287/mit-license) I am confused, because now I see that you may intend this (similar to GNU/Linux).

This may be one of the tiniest and most useless pull requests ever, but you got me curious. ;)
