### PR TITLE
error paths for additionalItems, additionalProperties and patternProperties

### DIFF
--- a/jsonschema.py
+++ b/jsonschema.py
@@ -179,6 +179,7 @@ class _Draft34CommonMixin(object):
             for k, v in iteritems(instance):
                 if re.search(pattern, k):
                     for error in self.iter_errors(v, subschema):
+                        error.path.appendleft(k)
                         yield error
 
     def validate_additionalProperties(self, aP, instance, schema):
@@ -190,6 +191,7 @@ class _Draft34CommonMixin(object):
         if self.is_type(aP, "object"):
             for extra in extras:
                 for error in self.iter_errors(instance[extra], aP):
+                    error.path.appendleft(extra)
                     yield error
         elif not aP and extras:
             error = "Additional properties are not allowed (%s %s unexpected)"
@@ -218,8 +220,10 @@ class _Draft34CommonMixin(object):
             return
 
         if self.is_type(aI, "object"):
-            for item in instance[len(schema):]:
+            for index, item in enumerate(
+                    instance[len(schema.get("items", [])):]):
                 for error in self.iter_errors(item, aI):
+                    error.path.appendleft(index)
                     yield error
         elif not aI and len(instance) > len(schema.get("items", [])):
             error = "Additional items are not allowed (%s %s unexpected)"

--- a/tests.py
+++ b/tests.py
@@ -415,6 +415,55 @@ class TestValidationErrorDetails(unittest.TestCase):
         self.assertEqual(e5.validator, "minItems")
         self.assertEqual(e6.validator, "enum")
 
+    def test_additionalProperties(self):
+        instance = {"bar": "bar", "foo": 2}
+        schema = {
+            "additionalProperties" : {"type": "integer", "minimum": 5}
+        }
+
+        errors = self.validator.iter_errors(instance, schema)
+        e1, e2 = sorted_errors(errors)
+
+        self.assertEqual(list(e1.path), ["bar"])
+        self.assertEqual(list(e2.path), ["foo"])
+
+        self.assertEqual(e1.validator, "type")
+        self.assertEqual(e2.validator, "minimum")
+
+    def test_patternProperties(self):
+        instance = {"bar": 1, "foo": 2}
+        schema = {
+            "patternProperties" : {
+                "bar": {"type": "string"},
+                "foo": {"minimum": 5}
+            }
+        }
+
+        errors = self.validator.iter_errors(instance, schema)
+        e1, e2 = sorted_errors(errors)
+
+        self.assertEqual(list(e1.path), ["bar"])
+        self.assertEqual(list(e2.path), ["foo"])
+
+        self.assertEqual(e1.validator, "type")
+        self.assertEqual(e2.validator, "minimum")
+
+    def test_additionalItems(self):
+        instance = ["foo", 1]
+        schema = {
+            "items": [],
+            "additionalItems" : {"type": "integer", "minimum": 5}
+        }
+
+        errors = self.validator.iter_errors(instance, schema)
+        e1, e2 = sorted_errors(errors)
+
+        self.assertEqual(list(e1.path), [0])
+        self.assertEqual(list(e2.path), [1])
+
+        self.assertEqual(e1.validator, "type")
+        self.assertEqual(e2.validator, "minimum")
+
 
 class TestErrorTree(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This fixes the additionalProperties error path problems issue in #74, which turns out was also affecting patternProperties and additionalItems.

This also fixes a problem with additionalItems, where it was not validating the correct items. See: https://github.com/gazpachoking/jsonschema/commit/4a7ffc107603e5a97462f5871f3c15a2f5430f1b#L0L221
