### PR TITLE
Fix error paths when additionalItems is used with items keyword

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -61,8 +61,8 @@ def additionalItems(validator, aI, instance, schema):
 
     len_items = len(schema.get("items", []))
     if validator.is_type(aI, "object"):
-        for index, item in enumerate(instance[len_items:]):
-            for error in validator.descend(item, aI, path=index+len_items):
+        for index, item in enumerate(instance[len_items:], start=len_items):
+            for error in validator.descend(item, aI, path=index):
                 yield error
     elif not aI and len(instance) > len(schema.get("items", [])):
         error = "Additional items are not allowed (%s %s unexpected)"

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -484,6 +484,23 @@ class TestValidationErrorDetails(unittest.TestCase):
         self.assertEqual(e2.validator, "minimum")
 
     def test_additionalItems(self):
+        instance = ["foo", 1]
+        schema = {
+            "items": [],
+            "additionalItems" : {"type": "integer", "minimum": 5}
+        }
+
+        validator = Draft3Validator(schema)
+        errors = validator.iter_errors(instance)
+        e1, e2 = sorted_errors(errors)
+
+        self.assertEqual(list(e1.path), [0])
+        self.assertEqual(list(e2.path), [1])
+
+        self.assertEqual(e1.validator, "type")
+        self.assertEqual(e2.validator, "minimum")
+
+    def test_additionalItems_with_items(self):
         instance = ["foo", "bar", 1]
         schema = {
             "items": [{}],


### PR DESCRIPTION
This should take care of the issue in #122
