### PR TITLE
Fix assertion in TestCreateAndExtend.test_iter_errors()

### DIFF
--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -47,9 +47,12 @@ class TestCreateAndExtend(unittest.TestCase):
         self.smelly.return_value = [error]
         self.assertEqual(list(self.validator.iter_errors(instance)), [error])
 
-        self.smelly.assert_called_with(
-            self.validator, self.validator_value, instance, self.schema,
-        )
+        assert list(self.smelly.call_args_list) == [
+            mock.call(
+                self.validator, self.validator_value, instance, self.schema),
+            mock.call(
+                self.validator, self.validator_value, instance, self.schema),
+        ]
 
     def test_if_a_version_is_provided_it_is_registered(self):
         with mock.patch("jsonschema.validators.validates") as validates:


### PR DESCRIPTION
The method `mock.assert_called_with()` does not exist. However, missing
methods on mocks always return True. To fix that, the `call_args_list`
attribute of the mock was used in the assertion instead.
