### PR TITLE
Update FAQ with example of using defaulting validator.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -47,9 +47,18 @@ started:
         DefaultValidatingDraft4Validator = extend_with_default(Draft4Validator)
 
 
+        # Example usage:
+        obj = {}
+        schema = {'properties': {'foo': {'default': 'bar'}}}
+        # Note jsonschem.validate(obj, schema, cls=DefaultValidatingDraft4Validator)
+        # will not work because the metaschema contains `default` directives.
+        DefaultValidatingDraft4Validator(schema).validate(obj)
+        assert obj == {'foo': 'bar'}
+
+
 See the above-linked document for more info on how this works, but basically,
 it just extends the :validator:`properties` validator on a
-:class:`Draft4Validator` to then go ahed and update all the defaults.
+:class:`Draft4Validator` to then go ahead and update all the defaults.
 
 If you're interested in a more interesting solution to a larger class of these
 types of transformations, keep an eye on `Seep


### PR DESCRIPTION
The faq example was useful but when used directly with the `validate` method it failed.  I felt the little tidbit about that would be useful to pass along.
