### PR TITLE
Fixes #126: generator objects leak on Python 3

### DIFF
--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -72,10 +72,11 @@ def create(meta_schema, validators=(), version=None, default_types=None):  # noq
 
         @classmethod
         def check_schema(cls, schema):
-            for error in cls(cls.META_SCHEMA).iter_errors(schema):
+            for error in list(cls(cls.META_SCHEMA).iter_errors(
+                    schema, _first_only=True)):
                 raise SchemaError.create_from(error)
 
-        def iter_errors(self, instance, _schema=None):
+        def iter_errors(self, instance, _schema=None, _first_only=False):
             if _schema is None:
                 _schema = self.schema
 
@@ -104,6 +105,9 @@ def create(meta_schema, validators=(), version=None, default_types=None):  # noq
                             error.schema_path.appendleft(k)
                         yield error
 
+                        if _first_only:
+                            return
+
         def descend(self, instance, schema, path=None, schema_path=None):
             for error in self.iter_errors(instance, schema):
                 if path is not None:
@@ -113,7 +117,8 @@ def create(meta_schema, validators=(), version=None, default_types=None):  # noq
                 yield error
 
         def validate(self, *args, **kwargs):
-            for error in self.iter_errors(*args, **kwargs):
+            kwargs['_first_only'] = True
+            for error in list(self.iter_errors(*args, **kwargs)):
                 raise error
 
         def is_type(self, instance, type):
@@ -132,8 +137,8 @@ def create(meta_schema, validators=(), version=None, default_types=None):  # noq
             return isinstance(instance, pytypes)
 
         def is_valid(self, instance, _schema=None):
-            error = next(self.iter_errors(instance, _schema), None)
-            return error is None
+            errors = list(self.iter_errors(instance, _schema, _first_only=True))
+            return not len(errors)
 
     if version is not None:
         Validator = validates(version)(Validator)


### PR DESCRIPTION
The issue here is that generator objects that don't run to completion are uncollectable.  There are a few places where `iter_errors` is called simply to retrieve the first error, and thus `iter_errors` is left uncompleted and holding references to a bunch of things (including `self`, which prevents deletion of the `iter_errors` generator instance).

The fix here isn't terribly elegant: It adds a kwarg to `iter_errors` to yield only the first error.  Then, this is used from the places that only want the first error (along with `list` to fully exhaust the generator).  The alternative (to just use `list`) would mean the possibly expensive creation of many error results only to have them immediately ignored and thrown away -- less efficient, but a simpler/less hackish solution perhaps.

Lastly, I couldn't figure out how to write a test for this: except perhaps to do:

```
warnings.filterwarnings("error", ".*", ResourceWarning)
```

which would raise an exception at the end of the test run rather than just a warning.
