### PR TITLE
Link from top-level docs page to GitHub?

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,10 @@ for Python (supporting 2.6+ including Python 3).
     ValidationError: 'Invalid' is not of type 'number'
 
 
+You can find further information (installation instructions, mailing list)
+as well as the source code and issue tracker on our
+`GitHub page <https://github.com/Julian/jsonschema/>`__.
+
 Contents:
 
 .. toctree::


### PR DESCRIPTION
Could you please add a link from the [jsonschema docs](https://python-jsonschema.readthedocs.org/en/latest/) to the [jsonschema Github](https://github.com/Julian/jsonschema) page?

(Or maybe even some more info like mailing list or install that is at the moment only available in the README on Github?)
