### PR TITLE
Avoid urljoin by catching the ultra common # ref

### DIFF
--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -278,25 +278,28 @@ class RefResolver(object):
 
         """
 
-        full_uri = urljoin(self.resolution_scope, ref)
-        uri, fragment = urldefrag(full_uri)
-        if not uri:
-            uri = self.base_uri
-
-        if uri in self.store:
-            document = self.store[uri]
+        if ref == '#':
+            yield self.store[self.base_uri]
         else:
-            try:
-                document = self.resolve_remote(uri)
-            except Exception as exc:
-                raise RefResolutionError(exc)
+            full_uri = urljoin(self.resolution_scope, ref)
+            uri, fragment = urldefrag(full_uri)
+            if not uri:
+                uri = self.base_uri
 
-        old_base_uri, self.base_uri = self.base_uri, uri
-        try:
-            with self.in_scope(uri):
-                yield self.resolve_fragment(document, fragment)
-        finally:
-            self.base_uri = old_base_uri
+            if uri in self.store:
+                document = self.store[uri]
+            else:
+                try:
+                    document = self.resolve_remote(uri)
+                except Exception as exc:
+                    raise RefResolutionError(exc)
+
+            old_base_uri, self.base_uri = self.base_uri, uri
+            try:
+                with self.in_scope(uri):
+                    yield self.resolve_fragment(document, fragment)
+            finally:
+                self.base_uri = old_base_uri
 
     def resolve_fragment(self, document, fragment):
         """


### PR DESCRIPTION
PR for #158.  Cut about half a second off the test suite for me, but has pretty substantial savings in my application (~30sec/150k rows).
