### PR TITLE
Support for freezing software like py2exe, pyinstaller or Cx_Freeze.

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -2,6 +2,7 @@ import itertools
 import json
 import re
 import os
+import sys
 
 from jsonschema.compat import str_types, MutableMapping, urlsplit
 
@@ -54,9 +55,14 @@ def load_schema(name):
 
     """
 
-    schema_dir = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "schemas",
-    )
+    if hasattr(sys, "frozen"):
+        schema_dir = os.path.join(
+            os.path.dirname(os.path.abspath(sys.executable)), "schemas",
+        )
+    else:
+        schema_dir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "schemas",
+        )
     with open(os.path.join(schema_dir, name + ".json")) as schema_file:
         return json.load(schema_file)
 


### PR DESCRIPTION
jsonschema doesn't work when "frozen", it will try to open the draft3.json and draft4.json files using invalid paths.

For instance, in the case of Cx_Freeze on Windows it will try to open something like: C:\path_to_build_dir\library.zip\schemas\draft3.json, obviously this fails because library.zip is a zip file, not a directory!

With this correction, the path would be C:\path_to_build_dir\schemas\draft*.json only when the application using jsonshema is frozen.
