### PR TITLE
Make exceptions picklable on Python 2.X

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -27,6 +27,10 @@ class _Error(Exception):
         schema_path=(),
         parent=None,
     ):
+        # Calling __init__ is important, because otherwise __reduce__ will
+        # return empty args tuple on Py2.7 and unpickling will fail because
+        # init requires at least one argument.
+        super(_Error, self).__init__(message)
         self.message = message
         self.path = self.relative_path = deque(path)
         self.schema_path = self.relative_schema_path = deque(schema_path)


### PR DESCRIPTION
It turns out exceptions raised by jsonschema weren't picklable in python 2.7 because `Exception.__reduce__` returned empty `Exception.args` tuple and ValidationError afterwards wasn't happy with being constructed without any arguments:

``` python

In [1]: import jsonschema

In [2]: import pickle

In [3]: pickle.loads(pickle.dumps(jsonschema.exceptions.ValidationError('foobar')))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-1c3ada2ffd2d> in <module>()
----> 1 pickle.loads(pickle.dumps(jsonschema.exceptions.ValidationError('foobar')))

/home/immerrr/.conda/envs/jsonschema/lib/python2.7/pickle.pyc in loads(str)
   1380 def loads(str):
   1381     file = StringIO(str)
-> 1382     return Unpickler(file).load()
   1383 
   1384 # Doctest

/home/immerrr/.conda/envs/jsonschema/lib/python2.7/pickle.pyc in load(self)
    856             while 1:
    857                 key = read(1)
--> 858                 dispatch[key](self)
    859         except _Stop, stopinst:
    860             return stopinst.value

/home/immerrr/.conda/envs/jsonschema/lib/python2.7/pickle.pyc in load_reduce(self)
   1131         args = stack.pop()
   1132         func = stack[-1]
-> 1133         value = func(*args)
   1134         stack[-1] = value
   1135     dispatch[REDUCE] = load_reduce

TypeError: __init__() takes at least 2 arguments (1 given)
```
