### PR TITLE
Make minimum validator work for very negaitve numbers

### DIFF
--- a/json/tests/draft3/optional/bignum.json
+++ b/json/tests/draft3/optional/bignum.json
@@ -22,6 +22,28 @@
         ]
     },
     {
+        "description": "integer",
+        "schema": {"type": "integer"},
+        "tests": [
+            {
+                "description": "a negative bignum is an integer",
+                "data": -12345678910111213141516171819202122232425262728293031,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "number",
+        "schema": {"type": "number"},
+        "tests": [
+            {
+                "description": "a negative bignum is a number",
+                "data": -98249283749234923498293171823948729348710298301928331,
+                "valid": true
+            }
+        ]
+    },
+    {
         "description": "string",
         "schema": {"type": "string"},
         "tests": [
@@ -53,6 +75,31 @@
             {
                 "description": "comparison works for high numbers",
                 "data": 972783798187987123879878123.188781371,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "integer comparison",
+        "schema": {"minimum": -18446744073709551615},
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -18446744073709551600,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "float comparison with high precision on negative numbers",
+        "schema": {
+            "minimum": -972783798187987123879878123.18878137,
+            "exclusiveMinimum": true
+        },
+        "tests": [
+            {
+                "description": "comparison works for very negative numbers",
+                "data": -972783798187987123879878123.188781371,
                 "valid": false
             }
         ]

--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -77,10 +77,10 @@ def minimum(validator, minimum, instance, schema):
         return
 
     if schema.get("exclusiveMinimum", False):
-        failed = float(instance) <= float(minimum)
+        failed = instance <= minimum
         cmp = "less than or equal to"
     else:
-        failed = float(instance) < float(minimum)
+        failed = instance < minimum
         cmp = "less than"
 
     if failed:
@@ -94,10 +94,10 @@ def maximum(validator, maximum, instance, schema):
         return
 
     if schema.get("exclusiveMaximum", False):
-        failed = float(instance) >= float(maximum)
+        failed = instance >= maximum
         cmp = "greater than or equal to"
     else:
-        failed = float(instance) > float(maximum)
+        failed = instance > maximum
         cmp = "greater than"
 
     if failed:


### PR DESCRIPTION
`float` conversion in `maximum` validator was already removed to make it work with very large numbers. Same should be done in `minimum` validator for very "large" negative numbers.
