### PR TITLE
Fix prefixItems index reporting in ValidationError

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -452,4 +452,9 @@ def prefixItems(validator, prefixItems, instance, schema):
         return
 
     for (index, item), subschema in zip(enumerate(instance), prefixItems):
-        yield from validator.descend(item, subschema, schema_path=index)
+        yield from validator.descend(
+            instance=item,
+            schema=subschema,
+            schema_path=index,
+            path=index,
+        )

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1156,10 +1156,10 @@ class TestValidationErrorDetails(TestCase):
                 "type",
                 "string",
                 1,
-                deque([]),
+                deque([0]),
                 {"type": "string"},
                 deque(["prefixItems", 0, "type"]),
-                "$",
+                "$[0]",
             ),
         )
         self.assertEqual(
@@ -1178,10 +1178,10 @@ class TestValidationErrorDetails(TestCase):
                 "maximum",
                 3,
                 5,
-                deque([]),
+                deque([3]),
                 {"maximum": 3},
                 deque(["prefixItems", 3, "maximum"]),
-                "$",
+                "$[3]",
             ),
         )
 


### PR DESCRIPTION
- Fixed an issue when a prefixItems mismatch was identified, ValidationError was neglecting to report the instance index in json_path and the various deque paths
- Updated unit test