### PR TITLE
Ensure proper sorting of list in error message

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -113,7 +113,7 @@ def extras_msg(extras):
         verb = "was"
     else:
         verb = "were"
-    return ", ".join(repr(extra) for extra in extras), verb
+    return ", ".join(repr(extra) for extra in sorted(extras)), verb
 
 
 def ensure_list(thing):

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -594,7 +594,7 @@ class TestValidationErrorMessages(TestCase):
         message = self.message_for(instance=["foo", "bar"], schema=schema)
         self.assertIn(
             message,
-            "Unevaluated items are not allowed ('foo', 'bar' were unexpected)",
+            "Unevaluated items are not allowed ('bar', 'foo' were unexpected)",
         )
 
     def test_unevaluated_properties(self):
@@ -609,7 +609,7 @@ class TestValidationErrorMessages(TestCase):
         self.assertEqual(
             message,
             "Unevaluated properties are not allowed "
-            "('foo', 'bar' were unexpected)",
+            "('bar', 'foo' were unexpected)",
         )
 
 


### PR DESCRIPTION
Fixes problem where error message was not consistent between runs, even when the inputs were the same (file to be validated and the schema to use).

This should make the outcomes predictable and eliminate the random factor from it. In fact the sorting already happens in 3 other places inside the library but that specific location was missed.

This was found while working on https://github.com/ansible/ansible-lint/pull/2035 and where we observed that the output did very randomly between two runs:
```
"Additional properties are not allowed ('when', 'pki_certificates', 'pki_realms', 'pki_authorities', 'pki_private_groups_present', 'pki_routes' were unexpected)"
"Additional properties are not allowed ('pki_private_groups_present', 'when', 'pki_authorities', 'pki_certificates', 'pki_realms', 'pki_routes' were unexpected)"
```

Not listing the allowed properties alphabetically is also not human-friendly as it make quite hard to spot specific entries, especially as the size of these list can grow considerably.