### PR TITLE
Fix exception when encountering numeric properties

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -98,9 +98,9 @@ def find_additional_properties(instance, schema):
     patterns = "|".join(schema.get("patternProperties", {}))
     for property in instance:
         if property not in properties:
-            if patterns and re.search(patterns, property):
+            if patterns and re.search(patterns, str(property)):
                 continue
-            yield property
+            yield str(property)
 
 
 def extras_msg(extras):

--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -21,7 +21,7 @@ def patternProperties(validator, patternProperties, instance, schema):
 
     for pattern, subschema in patternProperties.items():
         for k, v in instance.items():
-            if re.search(pattern, k):
+            if re.search(str(pattern), str(k)):
                 yield from validator.descend(
                     v, subschema, path=k, schema_path=pattern,
                 )


### PR DESCRIPTION
While JSON does not allow integers to be used as map keys, YAML does allow it and trying to validate such document caused an ugly exception.

Fixes: https://github.com/python-jsonschema/check-jsonschema/issues/89

This fix might not be correct but at least it addressing the exception and treating the value as a string. We might want to change the loader to ensure it does that but I was not sure where to do such a change.

Obviously that it will also need some tests so we prevent future regressions but I a was not sure how to add them. Feel free to add them if you know or just give me a hint.