### PR TITLE
Only validate unevaluated properties/items on applicable types

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -418,6 +418,8 @@ def if_(validator, if_schema, instance, schema):
 
 
 def unevaluatedItems(validator, unevaluatedItems, instance, schema):
+    if not validator.is_type(instance, "array"):
+        return
     evaluated_item_indexes = find_evaluated_item_indexes_by_schema(
         validator, instance, schema,
     )
@@ -431,6 +433,8 @@ def unevaluatedItems(validator, unevaluatedItems, instance, schema):
 
 
 def unevaluatedProperties(validator, unevaluatedProperties, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
     evaluated_property_keys = find_evaluated_property_keys_by_schema(
         validator, instance, schema,
     )

--- a/jsonschema/tests/test_jsonschema_test_suite.py
+++ b/jsonschema/tests/test_jsonschema_test_suite.py
@@ -347,11 +347,6 @@ TestDraft201909 = DRAFT201909.to_unittest_testcase(
             subject="unevaluatedItems",
         )(test)
         or skip(
-            message=bug(949),
-            subject="unevaluatedProperties",
-            case_description="non-object instances are valid",
-        )(test)
-        or skip(
             message="dynamicRef support isn't working yet.",
             subject="recursiveRef",
         )(test)
@@ -415,16 +410,6 @@ TestDraft202012 = DRAFT202012.to_unittest_testcase(
         or skip(
             message="Vocabulary support is not yet present.",
             subject="vocabulary",
-        )(test)
-        or skip(
-            message=bug(949),
-            subject="unevaluatedItems",
-            case_description="non-array instances are valid",
-        )(test)
-        or skip(
-            message=bug(949),
-            subject="unevaluatedProperties",
-            case_description="non-object instances are valid",
         )(test)
         or skip(
             message=bug(),

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -597,6 +597,11 @@ class TestValidationErrorMessages(TestCase):
             "Unevaluated items are not allowed ('bar', 'foo' were unexpected)",
         )
 
+    def test_unevaluated_items_on_invalid_type(self):
+        schema = {"type": "array", "unevaluatedItems": False}
+        message = self.message_for(instance="foo", schema=schema)
+        self.assertEqual(message, "'foo' is not of type 'array'")
+
     def test_unevaluated_properties(self):
         schema = {"type": "object", "unevaluatedProperties": False}
         message = self.message_for(
@@ -611,6 +616,11 @@ class TestValidationErrorMessages(TestCase):
             "Unevaluated properties are not allowed "
             "('bar', 'foo' were unexpected)",
         )
+
+    def test_unevaluated_properties_on_invalid_type(self):
+        schema = {"type": "object", "unevaluatedProperties": False}
+        message = self.message_for(instance="foo", schema=schema)
+        self.assertEqual(message, "'foo' is not of type 'object'")
 
 
 class TestValidationErrorDetails(TestCase):


### PR DESCRIPTION
Fixes attribute error when trying to validate `unevaluatedProperties` and `unevaluatedItems` on objects which aren't a `dict` or `list` respectively.