### PR TITLE
Mark library as typed (PEP-561)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ console_scripts =
     jsonschema = jsonschema.cli:main
 
 [options.package_data]
-jsonschema = schemas/*.json, schemas/*/*.json
+jsonschema = py.typed, schemas/*.json, schemas/*/*.json
 
 [flake8]
 ban-relative-imports = true


### PR DESCRIPTION
Avoids problems with mypy by officially declaring the library as typed.

> Skipping analyzing "jsonschema": module is installed, but missing library stubs or py.typed marker

See: https://peps.python.org/pep-0561/
