### PR TITLE
Fix fuzzer to include instrumentation

### DIFF
--- a/jsonschema/tests/fuzz_validate.py
+++ b/jsonschema/tests/fuzz_validate.py
@@ -36,6 +36,7 @@ def test_schemas(obj1, obj2):
 
 
 def main():
+    atheris.instrument_all()
     atheris.Setup(
         sys.argv,
         test_schemas.hypothesis.fuzz_one_input,


### PR DESCRIPTION
I noticed the fuzzer has been broken for a while (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37327) and this should fix it. It's related to some updates in Atheris -- I believe since this commit https://github.com/google/atheris/commit/0fb69ecd1f3cff719e21cf4d2b7e2cb7fb949f49

Another interesting update on the OSS-Fuzz side is that it now builds with code coverage. So once the fuzzer starts running again we should be able to see visualise how much of the code has been explored (by visiting https://oss-fuzz.com).