### PR TITLE
docs: Fix a few typos

### DIFF
--- a/jsonschema/_reflect.py
+++ b/jsonschema/_reflect.py
@@ -60,7 +60,7 @@ def _importAndCheckStack(importName):
     Import the given name as a module, then walk the stack to determine whether
     the failure was the module not existing, or some code in the module (for
     example a dependent import) failing.  This can be helpful to determine
-    whether any actual application code was run.  For example, to distiguish
+    whether any actual application code was run.  For example, to distinguish
     administrative error (entering the wrong module name), from programmer
     error (writing buggy code in a module that fails to import).
 

--- a/jsonschema/tests/_suite.py
+++ b/jsonschema/tests/_suite.py
@@ -217,7 +217,7 @@ def _someone_save_us_the_module_of_the_caller():
     """
     The FQON of the module 2nd stack frames up from here.
 
-    This is intended to allow us to dynamicallly return test case classes that
+    This is intended to allow us to dynamically return test case classes that
     are indistinguishable from being defined in the module that wants them.
 
     Otherwise, trial will mis-print the FQON, and copy pasting it won't re-run


### PR DESCRIPTION
There are small typos in:
- jsonschema/_reflect.py
- jsonschema/tests/_suite.py

Fixes:
- Should read `dynamically` rather than `dynamicallly`.
- Should read `distinguish` rather than `distiguish`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md