### PR TITLE
don't install tests and benchmarks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.build]
+exclude = [
+  "jsonschema/tests",
+  "jsonschema/benchmarks",
+]
+
 [project]
 name = "jsonschema"
 description = "An implementation of JSON Schema validation for Python"


### PR DESCRIPTION
`jsonschema` currently installed the whole `jsonschema` subfolder of this
repository, which includes tests and benchmarks. From my testing, those don't
need to be installed, so here's a patch to not install them.


<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1003.org.readthedocs.build/en/1003/

<!-- readthedocs-preview python-jsonschema end -->