### PR TITLE
Add some typing to the ``exceptions.py`` module

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -6,13 +6,16 @@ from __future__ import annotations
 from collections import defaultdict, deque
 from pprint import pformat
 from textwrap import dedent, indent
-from typing import ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 import heapq
 import itertools
 
 import attr
 
 from jsonschema import _utils
+
+if TYPE_CHECKING:
+    from jsonschema import _types
 
 WEAK_MATCHES: frozenset[str] = frozenset(["anyOf", "oneOf"])
 STRONG_MATCHES: frozenset[str] = frozenset()
@@ -66,10 +69,10 @@ class _Error(Exception):
         for error in context:
             error.parent = self
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self.message!r}>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         essential_for_verbose = (
             self.validator, self.validator_value, self.instance, self.schema,
         )
@@ -99,11 +102,11 @@ class _Error(Exception):
         )
 
     @classmethod
-    def create_from(cls, other):
+    def create_from(cls, other: _Error):
         return cls(**other._contents())
 
     @property
-    def absolute_path(self):
+    def absolute_path(self) -> deque[str | int]:
         parent = self.parent
         if parent is None:
             return self.relative_path
@@ -113,7 +116,7 @@ class _Error(Exception):
         return path
 
     @property
-    def absolute_schema_path(self):
+    def absolute_schema_path(self) -> deque[str | int]:
         parent = self.parent
         if parent is None:
             return self.relative_schema_path
@@ -123,7 +126,7 @@ class _Error(Exception):
         return path
 
     @property
-    def json_path(self):
+    def json_path(self) -> str:
         path = "$"
         for elem in self.absolute_path:
             if isinstance(elem, int):
@@ -132,7 +135,11 @@ class _Error(Exception):
                 path += "." + elem
         return path
 
-    def _set(self, type_checker=None, **kwargs):
+    def _set(
+        self,
+        type_checker: _types.TypeChecker | None = None,
+        **kwargs: Any,
+    ) -> None:
         if type_checker is not None and self._type_checker is _unset:
             self._type_checker = type_checker
 
@@ -188,7 +195,7 @@ class RefResolutionError(Exception):
 
     _cause = attr.ib()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self._cause)
 
 
@@ -197,10 +204,10 @@ class UndefinedTypeCheck(Exception):
     A type checker was asked to check a type it did not have registered.
     """
 
-    def __init__(self, type):
+    def __init__(self, type: str) -> None:
         self.type = type
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Type {self.type!r} is unknown to this type checker"
 
 

--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -4,6 +4,7 @@ Validation errors, and some surrounding helpers.
 from __future__ import annotations
 
 from collections import defaultdict, deque
+from collections.abc import Iterable, Mapping
 from pprint import pformat
 from textwrap import dedent, indent
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -31,17 +32,17 @@ class _Error(Exception):
     def __init__(
         self,
         message: str,
-        validator=_unset,
-        path=(),
-        cause=None,
+        validator: str | _utils.Unset = _unset,
+        path: Iterable[str | int] = (),
+        cause: Exception | None = None,
         context=(),
         validator_value=_unset,
-        instance=_unset,
-        schema=_unset,
-        schema_path=(),
-        parent=None,
-        type_checker=_unset,
-    ):
+        instance: Any = _unset,
+        schema: Mapping[str, Any] | bool | _utils.Unset = _unset,
+        schema_path: Iterable[str | int] = (),
+        parent: _Error | None = None,
+        type_checker: _types.TypeChecker | _utils.Unset = _unset,
+    ) -> None:
         super(_Error, self).__init__(
             message,
             validator,

--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -154,10 +154,14 @@ class _Error(Exception):
         )
         return dict((attr, getattr(self, attr)) for attr in attrs)
 
-    def _matches_type(self):
+    def _matches_type(self) -> bool:
         try:
-            expected = self.schema["type"]
+            # We ignore this as we want to simply crash if this happens
+            expected = self.schema["type"]  # type: ignore[index]
         except (KeyError, TypeError):
+            return False
+
+        if isinstance(self._type_checker, _utils.Unset):
             return False
 
         if isinstance(expected, str):


### PR DESCRIPTION
After getting the go-ahead in https://github.com/python-jsonschema/jsonschema/issues/1017 I thought I would test the waters both in size and scope of potential PRs.

Feel free to ask me to separate some of the commits into separate PRs. I thought this was quite manageable, especially if you go commit by commit.

----------------------

I thought I would start with a fairly self contained module (_and a module I interact with quite a lot with at work myself_).
I think most of the changes are pretty straight forward. The first commit is hardest to review and for now I focused on the attributes that I was most sure about, keeping harder ones for later.

The second and third commit "fix issues". I understand that these are not actual issues and that through the dynamicness of Python these code paths actually currently work. So: what is the desired action here? Add ignores to tell `mypy` we know this works? Or add some `isinstance` checks and attribute definitions to make the code actually type safe. I lean towards the latter but don't want to impose my personal preference on a project I am not involved with until now. I'm more than happy to change those commits to do something differenty!

Happy reviewing 😄 

Edit: Sorry for all the force pushes, after a helpful [comment](https://github.com/python/typeshed/issues/8662#issuecomment-1328039199) from @ AlexWaygood in the `typeshed` repo I found one issue with my initial PR.

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1019.org.readthedocs.build/en/1019/

<!-- readthedocs-preview python-jsonschema end -->