### PR TITLE
Use only ``autodoc`` to generate the API documentation

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,7 @@
+API Reference
+=============
+
+.. toctree::
+   :titlesonly:
+
+   /api/jsonschema/index

--- a/docs/api/jsonschema/exceptions/index.rst
+++ b/docs/api/jsonschema/exceptions/index.rst
@@ -1,0 +1,6 @@
+:py:mod:`jsonschema.exceptions`
+===============================
+
+.. automodule:: jsonschema.exceptions
+   :members:
+   :undoc-members:

--- a/docs/api/jsonschema/index.rst
+++ b/docs/api/jsonschema/index.rst
@@ -1,0 +1,20 @@
+:py:mod:`jsonschema`
+====================
+
+Submodules
+----------
+
+.. toctree::
+   :titlesonly:
+
+   /api/jsonschema/exceptions/index
+   /api/jsonschema/protocols/index
+   /api/jsonschema/validators/index
+ 
+Package summary
+---------------
+
+.. automodule:: jsonschema
+   :members:
+   :imported-members:
+

--- a/docs/api/jsonschema/protocols/index.rst
+++ b/docs/api/jsonschema/protocols/index.rst
@@ -1,0 +1,6 @@
+:py:mod:`jsonschema.protocols`
+==============================
+
+.. automodule:: jsonschema.protocols
+   :members:
+   :undoc-members:

--- a/docs/api/jsonschema/validators/index.rst
+++ b/docs/api/jsonschema/validators/index.rst
@@ -1,0 +1,6 @@
+:py:mod:`jsonschema.validators`
+===============================
+
+.. automodule:: jsonschema.validators
+   :members:
+   :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,14 +36,14 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
-
-    "autoapi.extension",
-    "sphinx_autodoc_typehints",
     "sphinx_copybutton",
     "sphinx_json_schema_spec",
     "sphinxcontrib.spelling",
     "sphinxext.opengraph",
 ]
+
+# Add typing annotations to signatures
+autodoc_typehints = "signature"
 
 cache_path = "_cache"
 
@@ -159,28 +159,3 @@ autosectionlabel_prefix_document = True
 # -- Options for sphinxcontrib-spelling -----------------------------------
 
 spelling_word_list_filename = "spelling-wordlist.txt"
-
-# -- Options for autoapi ----------------------------------------------------
-
-suppress_warnings = [
-    "autoapi.python_import_resolution",
-    "autoapi.toc_reference",
-    "epub.duplicated_toc_entry",
-]
-autoapi_root = "api"
-autoapi_ignore = [
-    "*/_[a-z]*.py",
-    "*/__main__.py",
-    "*/benchmarks/*",
-    "*/cli.py",
-    "*/tests/*",
-]
-autoapi_options = [
-    "members",
-    "undoc-members",
-    "show-module-summary",
-    "imported-members",
-]
-
-autoapi_type = "python"
-autoapi_dirs = [PACKAGE_SRC]

--- a/docs/validate.rst
+++ b/docs/validate.rst
@@ -58,6 +58,7 @@ versions.
 
 .. autoclass:: TypeChecker
     :members:
+    :noindex:
 
 .. autoexception:: jsonschema.exceptions.UndefinedTypeCheck
     :noindex:
@@ -88,7 +89,7 @@ given how common validating these types are.
 
 If you *do* want the generality, or just want to add a few specific additional
 types as being acceptable for a validator object, then you should update an
-existing `TypeChecker` or create a new one. You may then create a new
+existing `jsonschema.TypeChecker` or create a new one. You may then create a new
 `Validator` via `jsonschema.validators.extend`.
 
 .. testcode::
@@ -252,6 +253,7 @@ The supported mechanism for ensuring these dependencies are present is again as 
 
 .. autoclass:: FormatChecker
     :members:
+    :noindex:
     :exclude-members: cls_checks
 
     .. attribute:: checkers


### PR DESCRIPTION
As discussed in https://github.com/python-jsonschema/jsonschema/pull/1019 `autoapi` has some issues with typing annotations.

This creates almost parity with the current documentation. There are slight differences in lay-out and some additional classes get documented (they could be excluded by hand).
I tested this with the other PR and could build with `make html` without any validation errors. I'll rebase that PR on this one as a final test.