### PR TITLE
Harmonize annotations with python/typeshed#8608

### DIFF
--- a/jsonschema/_typing.py
+++ b/jsonschema/_typing.py
@@ -1,0 +1,14 @@
+"""
+Type aliases and utilities to help manage `typing` usage and type annotations.
+"""
+
+from collections.abc import Mapping, Sequence
+import typing
+
+Schema = Mapping[str, typing.Any]
+
+JsonObject = Mapping[str, typing.Any]
+
+JsonValue = typing.Union[
+    JsonObject, Sequence[typing.Any], str, int, float, bool, None
+]


### PR DESCRIPTION
I haven't had time to focus on `jsonschema` typing much recently, but I want to get things back on track. The first thing to do is to correct any drift between `jsonschema` and `typeshed`.
I'm going to try to produce a steady stream of very small PRs which get things back in sync.

This is therefore hopefully the first of a few changes.

---

python/typeshed#8608 introduced annotations for `create` which are not fully reflected here.

In order to reflect that state into `jsonschema`, a new module, `jsonschema._typing` is introduced. The purpose of `_typing` is to be a singular place for the library to define type aliases and any typing-related utilities which may be needed. This will let us use aliases like `_typing.JsonValue` in many locations where any valid JSON datatype is accepted.
The definitions can be refined over time as necessary.

Initial definitions in `_typing` are:
- Schema (any JSON object)
- JsonObject (any JSON object)
- JsonValue (any JSON value, including objects or sequences)

`Schema` is just another name for `JsonObject`. Perhaps it is not needed, but the name may help clarify things to a reader. It is not obvious at present whether or not it is a good or bad idea to notate it as such, but a similar Schema alias is defined in typeshed and seems to be working there to annotate things accurately.

These types are using `Mapping` and `Sequence` rather than `dict` or `list`. The rationale is that `jsonschema`'s logic does not dictate that the objects used *must* be defined in stdlib types or subtypes thereof. For example, a `collections.UserDict` could be used and should be accepted by the library (`UserDict` wraps but does not inherit from `dict`.)

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1027.org.readthedocs.build/en/1027/

<!-- readthedocs-preview python-jsonschema end -->