### PR TITLE
Make _store_schema_list thread safe

### DIFF
--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -102,12 +102,16 @@ def _id_of(schema):
 
 
 def _store_schema_list():
+    _vocabularies: list[tuple[str, typing.Any]] = []
     if not _VOCABULARIES:
         package = _utils.resources.files(__package__)
         for version in package.joinpath("schemas", "vocabularies").iterdir():
             for path in version.iterdir():
                 vocabulary = json.loads(path.read_text())
-                _VOCABULARIES.append((vocabulary["$id"], vocabulary))
+                _vocabularies.append((vocabulary["$id"], vocabulary))
+
+        _VOCABULARIES.extend(_vocabularies)
+
     return [
         (id, validator.META_SCHEMA) for id, validator in _META_SCHEMAS.items()
     ] + _VOCABULARIES


### PR DESCRIPTION
I'm using `jsonschema` through [`altair`](https://github.com/altair-viz/altair) and as of version 4.17.1 I've been _occasionally_ running into issues when generating plots in parallel (using threading): The commit that broke things for me is [4f8f3](https://github.com/python-jsonschema/jsonschema/commit/4f8f346cc475439715833ac6bd6e5c5e3dc21ee3#diff-d38128373c229147d38e1c4707cdecd7e510c14eef80565374fe9a69627e4676R105-R111), where it makes a difference for me if I'm calling `.append(...)` in a loop or `.extend(...)` only once. The reason is that some of my threads end up with an incomplete list of `_VOCABULARIES`.

I understand that `jsonschema` is not advertising to be threadsafe (xref https://github.com/python-jsonschema/jsonschema/issues/464), but would you still consider merging this patch? I'm imitating the style of `_store_schema_list` from before 4f8f346cc475439715833ac6bd6e5c5e3dc21ee3.

I should add that my patch doesn't make the function thread safe, just a little bit thread saf*er*.

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1032.org.readthedocs.build/en/1032/

<!-- readthedocs-preview python-jsonschema end -->