### PR TITLE
Raise for status when fetching w/ requests

### DIFF
--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -2323,5 +2323,8 @@ class _ReallyFakeJSONResponse:
 
     _response = attr.ib()
 
+    def raise_for_status(self):
+        return None
+
     def json(self):
         return json.loads(self._response)

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -1013,7 +1013,9 @@ class RefResolver:
         elif scheme in ["http", "https"] and requests:
             # Requests has support for detecting the correct encoding of
             # json over http
-            result = requests.get(uri).json()
+            response = requests.get(uri)
+            response.raise_for_status()
+            result = response.json()
         else:
             # Otherwise, pass off to urllib and assume utf-8
             with urlopen(uri) as url:


### PR DESCRIPTION
In the case of (e.g.) 404 errors that still return a response, this will let the 404 error propagate instead of a JSON decode error (if the response isn't JSON). See the last paragraph of https://requests.readthedocs.io/en/latest/user/quickstart/#json-response-content for some text about this.