### PR TITLE
documentation mistype fix

### DIFF
--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -1208,7 +1208,7 @@ def validate(instance, schema, cls=None, *args, **kwargs):  # noqa: D417
     if you intend to validate multiple instances with
     the same schema, you likely would prefer using the
     `jsonschema.protocols.Validator.validate` method directly on a
-    specific validator (e.g. ``Draft20212Validator.validate``).
+    specific validator (e.g. ``Draft202012Validator.validate``).
 
 
     Arguments:


### PR DESCRIPTION
Draft202012Validator.validate instead of Draft20212Validator.validate

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1063.org.readthedocs.build/en/1063/

<!-- readthedocs-preview python-jsonschema end -->