### PR TITLE
Treat invalid pattern property as unevaluated

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -291,10 +291,10 @@ def find_evaluated_property_keys_by_schema(validator, instance, schema):
 
     if "patternProperties" in schema:
         for property, value in instance.items():
-            for pattern, _ in schema["patternProperties"].items():
+            for pattern, subschema in schema["patternProperties"].items():
                 if re.search(pattern, property) and validator.evolve(
-                    schema=schema["patternProperties"],
-                ).is_valid({property: value}):
+                    schema=subschema,
+                ).is_valid(value):
                     evaluated_keys.append(property)
 
     if "dependentSchemas" in schema:

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -694,7 +694,8 @@ class TestValidationErrorMessages(TestCase):
             },
             schema=schema,
         )
-        error = [e for e in errors if e.validator == "unevaluatedProperties"][0]
+        error = [e for e in errors
+                 if e.validator == "unevaluatedProperties"][0]
         self.assertEqual(
             error.message,
             "Unevaluated properties are not allowed "


### PR DESCRIPTION
This addresses an "error message" issue, not a validation issue, so no need to update the test suite.

For regular properties, a property which failed validation would be also deemed "unevaluated", thus resulting in two messages, e.g.
```python
validate(
    schema={"properties": {"foo": {"type": "string"}}},
    instance={"foo": 42},
)
```
would result in 2 errors:
- 42 is not of type 'string'
- unevaluated property 'foo'

With this change, pattern properties would have the same behavior:
```python
validate(
    schema={"patternProperties": {"^foo": {"type": "string"}}},
    instance={"foo": 42},
)
```

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1073.org.readthedocs.build/en/1073/

<!-- readthedocs-preview python-jsonschema end -->