### PR TITLE
Do not validate for unevaluatedProperties

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -275,12 +275,13 @@ def find_evaluated_property_keys_by_schema(validator, instance, schema):
         "properties", "additionalProperties", "unevaluatedProperties",
     ]:
         if keyword in schema:
-            if validator.is_type(schema[keyword], "boolean") and schema[keyword]:
+            schema_value = schema[keyword]
+            if validator.is_type(schema_value, "boolean") and schema_value:
                 for property, value in instance.items():
                     evaluated_keys.append(property)
 
-            elif validator.is_type(schema[keyword], "object"):
-                for property, subschema in schema[keyword].items():
+            elif validator.is_type(schema_value, "object"):
+                for property, subschema in schema_value.items():
                     if property in instance:
                         evaluated_keys.append(property)
 

--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -275,26 +275,19 @@ def find_evaluated_property_keys_by_schema(validator, instance, schema):
         "properties", "additionalProperties", "unevaluatedProperties",
     ]:
         if keyword in schema:
-            if validator.is_type(schema[keyword], "boolean"):
+            if validator.is_type(schema[keyword], "boolean") and schema[keyword]:
                 for property, value in instance.items():
-                    if validator.evolve(schema=schema[keyword]).is_valid(
-                        {property: value},
-                    ):
-                        evaluated_keys.append(property)
+                    evaluated_keys.append(property)
 
-            if validator.is_type(schema[keyword], "object"):
+            elif validator.is_type(schema[keyword], "object"):
                 for property, subschema in schema[keyword].items():
-                    if property in instance and validator.evolve(
-                        schema=subschema,
-                    ).is_valid(instance[property]):
+                    if property in instance:
                         evaluated_keys.append(property)
 
     if "patternProperties" in schema:
         for property, value in instance.items():
-            for pattern, _ in schema["patternProperties"].items():
-                if re.search(pattern, property) and validator.evolve(
-                    schema=schema["patternProperties"],
-                ).is_valid({property: value}):
+            for pattern in schema["patternProperties"]:
+                if re.search(pattern, property):
                     evaluated_keys.append(property)
 
     if "dependentSchemas" in schema:

--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -277,16 +277,15 @@ def find_evaluated_property_keys_by_schema(validator, instance, schema):
         if keyword in schema:
             schema_value = schema[keyword]
             if validator.is_type(schema_value, "boolean") and schema_value:
-                for property, value in instance.items():
-                    evaluated_keys.append(property)
+                evaluated_keys += instance.keys()
 
             elif validator.is_type(schema_value, "object"):
-                for property, subschema in schema_value.items():
+                for property in schema_value:
                     if property in instance:
                         evaluated_keys.append(property)
 
     if "patternProperties" in schema:
-        for property, value in instance.items():
+        for property in instance:
             for pattern in schema["patternProperties"]:
                 if re.search(pattern, property):
                     evaluated_keys.append(property)


### PR DESCRIPTION
It appears that without checking `is_valid` the test suite still passes. The invalid properties already produce an error, so that the "unevaluated property" error is never _needed_ to achieve a validation failure. On the contrary, when all property validation succeeds, "unevaluated property" could still produce an error.

Arguably, producing an error for expected but invalid properties is also confusing, being a "double jeopardy" of validation failures.

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1075.org.readthedocs.build/en/1075/

<!-- readthedocs-preview python-jsonschema end -->