### PR TITLE
Replace lambda with def

### DIFF
--- a/jsonschema/_types.py
+++ b/jsonschema/_types.py
@@ -186,13 +186,15 @@ draft3_type_checker = TypeChecker(
     },
 )
 draft4_type_checker = draft3_type_checker.remove("any")
-draft6_type_checker = draft4_type_checker.redefine(
-    "integer",
-    lambda checker, instance: (
+
+
+def _draft6_is_integer(checker, instance) -> bool:
+    return (
         is_integer(checker, instance)
         or isinstance(instance, float) and instance.is_integer()
-    ),
-)
+    )
+
+draft6_type_checker = draft4_type_checker.redefine("integer", _draft6_is_integer)
 draft7_type_checker = draft6_type_checker
 draft201909_type_checker = draft7_type_checker
 draft202012_type_checker = draft201909_type_checker


### PR DESCRIPTION
I'm running into an issue when trying to use jsonschema with concurrent.futures to check multiple schema in parallel. It is complaining that it can't pickle a lambda function. Changing this lambda to a globally defined function fixes the issue. 

Currently pretty tight on time, so this PR is only the change without a test or MWE to demonstrate the issue, but I think it's simple enough and the rational is reasonble enough. 

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1083.org.readthedocs.build/en/1083/

<!-- readthedocs-preview python-jsonschema end -->