### PR TITLE
fix: hostname format check on empty string raises ValueError

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -270,6 +270,7 @@ with suppress(ImportError):
         draft7="hostname",
         draft201909="hostname",
         draft202012="hostname",
+        raises=ValueError,
     )
     def is_host_name(instance: object) -> bool:
         if not isinstance(instance, str):


### PR DESCRIPTION
Doing hostname format check on empty string seems to raise a ValueError:

    >>> from jsonschema.validators import validator_for
    >>> schema = {"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "string", "format": "hostname"}
    >>> vcls = validator_for(schema)
    >>> validator = vcls(schema, format_checker=vcls.FORMAT_CHECKER)
    >>> list(validator.iter_errors(""))
    ...
      File "lib/python3.10/site-packages/jsonschema/_format.py", line 276, in is_host_name
        return FQDN(instance).is_valid
      File "lib/python3.10/site-packages/fqdn/__init__.py", line 44, in __init__
        raise ValueError("fqdn must be str")
    ValueError: fqdn must be str

Fix by adding `raises=ValueError` to the related `@_checks_drafts` decorator call.

See also json-schema-org/JSON-Schema-Test-Suite#677.

Fixes #1121.

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1127.org.readthedocs.build/en/1127/

<!-- readthedocs-preview python-jsonschema end -->