### PR TITLE
Preserve $ref history.

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -51,6 +51,7 @@ class _Error(Exception):
         schema_path=(),
         parent=None,
         type_checker=_unset,
+        refs=()
     ):
         super().__init__(
             message,
@@ -63,6 +64,7 @@ class _Error(Exception):
             schema,
             schema_path,
             parent,
+            refs,
         )
         self.message = message
         self.path = self.relative_path = deque(path)
@@ -74,6 +76,7 @@ class _Error(Exception):
         self.instance = instance
         self.schema = schema
         self.parent = parent
+        self.refs = deque(refs)
         self._type_checker = type_checker
 
         for error in context:
@@ -156,7 +159,7 @@ class _Error(Exception):
     def _contents(self):
         attrs = (
             "message", "cause", "context", "validator", "validator_value",
-            "path", "schema_path", "instance", "schema", "parent",
+            "path", "schema_path", "instance", "schema", "parent", "refs",
         )
         return dict((attr, getattr(self, attr)) for attr in attrs)
 

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1485,6 +1485,18 @@ class TestValidationErrorDetails(TestCase):
             ),
         )
 
+    def test_ref_history(self):
+        schema = {
+            "$defs": {"foo": {"properties":{"prop":{"$ref":"#/$defs/bar"},},},
+                      "bar": {"properties":{"a":{"type":"integer"},},},},
+            "$ref": "#/$defs/foo"
+        }
+        instance = {"prop": {"a":"1",}}
+
+        validator = validators._LATEST_VERSION(schema)
+        e, = list(validator.iter_errors(instance))
+        self.assertEqual(list(e.refs), ["#/$defs/foo", "#/$defs/bar"])
+
 
 class MetaSchemaTestsMixin:
     # TODO: These all belong upstream

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -369,6 +369,8 @@ def create(
                         schema=_schema,
                         type_checker=self.TYPE_CHECKER,
                     )
+                    if k == "$ref":
+                        error.refs.appendleft(v)
                     if k not in {"if", "$ref"}:
                         error.schema_path.appendleft(k)
                     yield error
@@ -417,6 +419,8 @@ def create(
                         schema=schema,
                         type_checker=evolved.TYPE_CHECKER,
                     )
+                    if k == "$ref":
+                        error.refs.appendleft(v)
                     if k not in {"if", "$ref"}:
                         error.schema_path.appendleft(k)
                     if path is not None:


### PR DESCRIPTION
In large schemas, understanding which $ref is being referenced when an error occurs can be helpful in debugging. We used to refer to the history of $ref with code like this:

```python
for error in validator.iter_errors(instance):
    print(validator.resolver._scopes_stack)
    print(error)
```

However, with the current version of jsonschema, validator.resolver is deprecated, and it will be not possible to refer to it.

In this PR, I have made changes so that the history of $ref is recorded in the exception object when an error occurs, and the $ref from the root to the part where the error occurred can be referred to with `error.refs`. I believe this feature will be useful not only for us, but for many users as well.

