### PR TITLE
Faster pprint

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -216,8 +216,18 @@ easier debugging.
     3 is not valid under any of the given schemas
 
     Failed validating 'anyOf' in schema['items']:
-        {'anyOf': [{'maxLength': 2, 'type': 'string'},
-                   {'minimum': 5, 'type': 'integer'}]}
+        {
+          "anyOf": [
+            {
+              "maxLength": 2,
+              "type": "string"
+            },
+            {
+              "minimum": 5,
+              "type": "integer"
+            }
+          ]
+        }
 
     On instance[1]:
         3

--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -4,7 +4,7 @@ Validation errors, and some surrounding helpers.
 from __future__ import annotations
 
 from collections import defaultdict, deque
-from pprint import pformat
+import json
 from textwrap import dedent, indent
 from typing import ClassVar
 import heapq
@@ -32,6 +32,9 @@ def __getattr__(name):
         return _RefResolutionError
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
+
+def _format_json(obj):
+    return json.dumps(obj, ensure_ascii=False, indent=2)
 
 class _Error(Exception):
 
@@ -104,10 +107,10 @@ class _Error(Exception):
             {self.message}
 
             Failed validating {self.validator!r} in {schema_path}:
-                {indent(pformat(self.schema, width=72), prefix).lstrip()}
+                {indent(_format_json(self.schema), prefix).lstrip()}
 
             On {instance_path}:
-                {indent(pformat(self.instance, width=72), prefix).lstrip()}
+                {indent(_format_json(self.instance), prefix).lstrip()}
             """.rstrip(),
         )
 
@@ -268,10 +271,10 @@ class UnknownType(Exception):
         return dedent(
             f"""\
             Unknown type {self.type!r} for validator with schema:
-                {indent(pformat(self.schema, width=72), prefix).lstrip()}
+                {indent(_format_json(self.schema), prefix).lstrip()}
 
             While checking instance:
-                {indent(pformat(self.instance, width=72), prefix).lstrip()}
+                {indent(_format_json(self.instance), prefix).lstrip()}
             """.rstrip(),
         )
 

--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -4,11 +4,11 @@ Validation errors, and some surrounding helpers.
 from __future__ import annotations
 
 from collections import defaultdict, deque
-import json
 from textwrap import dedent, indent
 from typing import ClassVar
 import heapq
 import itertools
+import json
 import warnings
 
 from attrs import define
@@ -34,7 +34,8 @@ def __getattr__(name):
 
 
 def _format_json(obj):
-    return json.dumps(obj, ensure_ascii=False, indent=2)
+    return json.dumps(obj, ensure_ascii=False, indent=2, default=repr,
+                      sort_keys=True)
 
 class _Error(Exception):
 

--- a/jsonschema/tests/test_exceptions.py
+++ b/jsonschema/tests/test_exceptions.py
@@ -478,7 +478,9 @@ class TestErrorInitReprStr(TestCase):
         self.assertShows(
             """
             Failed validating 'type' in schema:
-                {'type': 'string'}
+                {
+                  "type": "string"
+                }
 
             On instance:
                 5
@@ -491,7 +493,9 @@ class TestErrorInitReprStr(TestCase):
         self.assertShows(
             """
             Failed validating 'type' in schema:
-                {'type': 'string'}
+                {
+                  "type": "string"
+                }
 
             On instance[0]:
                 5
@@ -504,7 +508,9 @@ class TestErrorInitReprStr(TestCase):
         self.assertShows(
             """
             Failed validating 'type' in schema['items'][0]:
-                {'type': 'string'}
+                {
+                  "type": "string"
+                }
 
             On instance[0]['a']:
                 5
@@ -517,53 +523,57 @@ class TestErrorInitReprStr(TestCase):
         self.assertShows(
             """
             Failed validating 'maxLength' in schema:
-                {0: 0,
-                 1: 1,
-                 2: 2,
-                 3: 3,
-                 4: 4,
-                 5: 5,
-                 6: 6,
-                 7: 7,
-                 8: 8,
-                 9: 9,
-                 10: 10,
-                 11: 11,
-                 12: 12,
-                 13: 13,
-                 14: 14,
-                 15: 15,
-                 16: 16,
-                 17: 17,
-                 18: 18,
-                 19: 19}
+                {
+                  "0": 0,
+                  "1": 1,
+                  "2": 2,
+                  "3": 3,
+                  "4": 4,
+                  "5": 5,
+                  "6": 6,
+                  "7": 7,
+                  "8": 8,
+                  "9": 9,
+                  "10": 10,
+                  "11": 11,
+                  "12": 12,
+                  "13": 13,
+                  "14": 14,
+                  "15": 15,
+                  "16": 16,
+                  "17": 17,
+                  "18": 18,
+                  "19": 19
+                }
 
             On instance:
-                [0,
-                 1,
-                 2,
-                 3,
-                 4,
-                 5,
-                 6,
-                 7,
-                 8,
-                 9,
-                 10,
-                 11,
-                 12,
-                 13,
-                 14,
-                 15,
-                 16,
-                 17,
-                 18,
-                 19,
-                 20,
-                 21,
-                 22,
-                 23,
-                 24]
+                [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15,
+                  16,
+                  17,
+                  18,
+                  19,
+                  20,
+                  21,
+                  22,
+                  23,
+                  24
+                ]
             """,
             instance=list(range(25)),
             schema=dict(zip(range(20), range(20))),


### PR DESCRIPTION
jsonschema can sometimes be very slow when validation errors occur. This is due to the slow formatting of large schemas or data with pprint.pformat(). In this PR, I propose replacing pprint.pformat() with json.dumps(), which is expected to perform more than 10 times faster.

The following samples measure the time taken to format 300 GitHub PRs.

### pprint.pformat()
```sh
$ python3 -m timeit -s "import requests, pprint;L=requests.get('https://api.github.com/repos/python/cpython/pulls?state=all').json() * 100" "pprint.pformat(L)"
1 loop, best of 5: 14.2 sec per loop
```

### json.dumps()
```sh
$ python3 -m timeit -s "import requests, json;L=requests.get('https://api.github.com/repos/python/cpython/pulls?state=all').json() * 100" "json.dumps(L, ensure_ascii=False, indent=2, default=repr)"
1 loop, best of 5: 1.19 sec per loop
```

(Memo: If it's possible to add as a dependency, using orjson would make it more than 10 times faster.)

```sh
python3 -m timeit -s "import requests, orjson;L=requests.get('https://api.github.com/repos/python/cpython/pulls?state=all').json() * 100" "orjson.dumps(L, option=orjson.OPT_INDENT_2|orjson.OPT_SORT_KEYS, default=repr)"
5 loops, best of 5: 79.2 msec per loop
```

json.dumps() does not perform wordwrapping or other formatting pformat() does. However, such formatting can insert unnecessary newline characters into the data, sometimes making debugging hard. I believe it's more appropriate not to perform such modifications.

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1145.org.readthedocs.build/en/1145/

<!-- readthedocs-preview python-jsonschema end -->