### PR TITLE
Allow single label hostname in format string

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -274,7 +274,7 @@ with suppress(ImportError):
     def is_host_name(instance: object) -> bool:
         if not isinstance(instance, str):
             return True
-        return FQDN(instance).is_valid
+        return FQDN(instance, min_labels=1).is_valid
 
 
 with suppress(ImportError):


### PR DESCRIPTION
When validating hostname format strings with module fqdn, only FQDNs were accepted, as the minimum label length of the FQDN class is 2. Therefore, single label hostnames like "localhost" were rejected.

Fixed this by validating with a minimum label length of 1.

- Tests: json-schema-org/JSON-Schema-Test-Suite#685
- Fixes: python-jsonschema/jsonschema#1162

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1164.org.readthedocs.build/en/1164/

<!-- readthedocs-preview python-jsonschema end -->