### PR TITLE
Check for the `"deprecated"` keyword

### DIFF
--- a/jsonschema/_keywords.py
+++ b/jsonschema/_keywords.py
@@ -447,3 +447,8 @@ def prefixItems(validator, prefixItems, instance, schema):
             schema_path=index,
             path=index,
         )
+
+
+def deprecated(validator, deprecated, instance, schema):
+    if validator.check_deprecated and deprecated is True:
+        yield ValidationError(f"{instance!r} is deprecated")

--- a/jsonschema/protocols.py
+++ b/jsonschema/protocols.py
@@ -81,6 +81,12 @@ class Validator(Protocol):
             its `extra (optional) dependencies <index:extras>` when
             invoking ``pip``.
 
+        check_deprecated:
+
+            if ``True``, raise validation errors when the :kw:`deprecated`
+            keyword is ``true`` for an instance value, indicating it should not
+            be used and may be removed in the future.
+
     .. deprecated:: v4.12.0
 
         Subclassing validator classes now explicitly warns this is not part of
@@ -216,7 +222,7 @@ class Validator(Protocol):
 
         >>> validator = Draft202012Validator({})
         >>> validator.evolve(schema={"type": "number"})
-        Draft202012Validator(schema={'type': 'number'}, format_checker=None)
+        Draft202012Validator(schema={'type': 'number'}, format_checker=None, check_deprecated=False)
 
         The returned object satisfies the validator protocol, but may not
         be of the same concrete class! In particular this occurs
@@ -226,5 +232,5 @@ class Validator(Protocol):
         >>> validator.evolve(
         ...     schema={"$schema": Draft7Validator.META_SCHEMA["$id"]}
         ... )
-        Draft7Validator(schema=..., format_checker=None)
-        """
+        Draft7Validator(schema=..., format_checker=None, check_deprecated=False)
+        """  # noqa: E501

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -229,6 +229,7 @@ def create(
         schema: referencing.jsonschema.Schema = field(repr=reprlib.repr)
         _ref_resolver = field(default=None, repr=False, alias="resolver")
         format_checker: _format.FormatChecker | None = field(default=None)
+        check_deprecated: bool = field(default=False)
         # TODO: include new meta-schemas added at runtime
         _registry: referencing.jsonschema.SchemaRegistry = field(
             default=_REMOTE_WARNING_REGISTRY,
@@ -758,6 +759,7 @@ Draft201909Validator = create(
         "contains": _keywords.contains,
         "dependentRequired": _keywords.dependentRequired,
         "dependentSchemas": _keywords.dependentSchemas,
+        "deprecated": _keywords.deprecated,
         "enum": _keywords.enum,
         "exclusiveMaximum": _keywords.exclusiveMaximum,
         "exclusiveMinimum": _keywords.exclusiveMinimum,
@@ -805,6 +807,7 @@ Draft202012Validator = create(
         "contains": _keywords.contains,
         "dependentRequired": _keywords.dependentRequired,
         "dependentSchemas": _keywords.dependentSchemas,
+        "deprecated": _keywords.deprecated,
         "enum": _keywords.enum,
         "exclusiveMaximum": _keywords.exclusiveMaximum,
         "exclusiveMinimum": _keywords.exclusiveMinimum,


### PR DESCRIPTION
Closes https://github.com/python-jsonschema/jsonschema/issues/1170

<!-- readthedocs-preview python-jsonschema start -->
----
:books: Documentation preview :books:: https://python-jsonschema--1171.org.readthedocs.build/en/1171/

<!-- readthedocs-preview python-jsonschema end -->