### PR TITLE
Wrong behaviour for enum keyword

### DIFF
--- a/jsonschema/_keywords.py
+++ b/jsonschema/_keywords.py
@@ -8,7 +8,6 @@ from jsonschema._utils import (
     find_additional_properties,
     find_evaluated_item_indexes_by_schema,
     find_evaluated_property_keys_by_schema,
-    unbool,
     uniq,
 )
 from jsonschema.exceptions import FormatError, ValidationError

--- a/jsonschema/_keywords.py
+++ b/jsonschema/_keywords.py
@@ -264,11 +264,7 @@ def dependentSchemas(validator, dependentSchemas, instance, schema):
 
 
 def enum(validator, enums, instance, schema):
-    if instance == 0 or instance == 1:
-        unbooled = unbool(instance)
-        if all(unbooled != unbool(each) for each in enums):
-            yield ValidationError(f"{instance!r} is not one of {enums!r}")
-    elif instance not in enums:
+    if all(not equal(each, instance) for each in enums):
         yield ValidationError(f"{instance!r} is not one of {enums!r}")
 
 


### PR DESCRIPTION
The following schema accepts the instance although it should be rejected:

```python
from jsonschema import validate
schema = {
    "enum": [
        [False]
    ],
    "$schema": "https://json-schema.org/draft/2020-12/schema"
}
instance = [0]
validate(instance, schema)  # erroneously accepts the instance
```

I guess, this is caused by the following line:
https://github.com/python-jsonschema/jsonschema/blob/256dadd3539861ae696c03805923eb4097b871f9/jsonschema/_keywords.py#L271

(`[0] in [[False]]` is true, so `[0] not in [[False]]` is false)


<!-- readthedocs-preview python-jsonschema start -->
----
📚 Documentation preview 📚: https://python-jsonschema--1208.org.readthedocs.build/en/1208/

<!-- readthedocs-preview python-jsonschema end -->