### PR TITLE
Update README.md

### DIFF
--- a/json/README.md
+++ b/json/README.md
@@ -261,6 +261,7 @@ This suite is being used by:
 * [Justify](https://github.com/leadpony/justify)
 * [Snow](https://github.com/ssilverman/snowy-json)
 * [jsonschemafriend](https://github.com/jimblackler/jsonschemafriend)
+* [OpenAPI JSON Schema Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator)
 
 ### JavaScript
 


### PR DESCRIPTION
Adds Openapi Json Schema Generator to java section because it now support generating and validating schemas in Java
Per the latest release:
https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/releases/tag/4.1.0

<!-- readthedocs-preview python-jsonschema start -->
----
📚 Documentation preview 📚: https://python-jsonschema--1217.org.readthedocs.build/en/1217/

<!-- readthedocs-preview python-jsonschema end -->