### PR TITLE
Check for identity before equality when comparing objects with `equal` (used in a number of keywords)

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -131,6 +131,8 @@ def equal(one, two):
     Specifically in JSON Schema, evade `bool` inheriting from `int`,
     recursing into sequences to do the same.
     """
+    if one is two:
+        return True
     if isinstance(one, str) or isinstance(two, str):
         return one == two
     if isinstance(one, Sequence) and isinstance(two, Sequence):

--- a/jsonschema/tests/test_utils.py
+++ b/jsonschema/tests/test_utils.py
@@ -1,3 +1,4 @@
+from math import nan
 from unittest import TestCase
 
 from jsonschema._utils import equal
@@ -7,11 +8,19 @@ class TestEqual(TestCase):
     def test_none(self):
         self.assertTrue(equal(None, None))
 
+    def test_nan(self):
+        self.assertTrue(equal(nan, nan))
+
 
 class TestDictEqual(TestCase):
     def test_equal_dictionaries(self):
         dict_1 = {"a": "b", "c": "d"}
         dict_2 = {"c": "d", "a": "b"}
+        self.assertTrue(equal(dict_1, dict_2))
+
+    def test_equal_dictionaries_with_nan(self):
+        dict_1 = {"a": nan, "c": "d"}
+        dict_2 = {"c": "d", "a": nan}
         self.assertTrue(equal(dict_1, dict_2))
 
     def test_missing_key(self):
@@ -68,6 +77,11 @@ class TestListEqual(TestCase):
     def test_equal_lists(self):
         list_1 = ["a", "b", "c"]
         list_2 = ["a", "b", "c"]
+        self.assertTrue(equal(list_1, list_2))
+
+    def test_equal_lists_with_nan(self):
+        list_1 = ["a", nan, "c"]
+        list_2 = ["a", nan, "c"]
         self.assertTrue(equal(list_1, list_2))
 
     def test_unsorted_lists(self):


### PR DESCRIPTION
This addresses #1223 

<!-- readthedocs-preview python-jsonschema start -->
----
📚 Documentation preview 📚: https://python-jsonschema--1224.org.readthedocs.build/en/1224/

<!-- readthedocs-preview python-jsonschema end -->