### PR TITLE
fix: Ignore validators set to 'None'

### DIFF
--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -46,7 +46,7 @@ class TestCreateAndExtend(TestCase):
         )
 
         self.meta_schema = {"$id": "some://meta/schema"}
-        self.validators = {"fail": fail}
+        self.validators = {"fail": fail, "none": None}
         self.type_checker = TypeChecker()
         self.Validator = validators.create(
             meta_schema=self.meta_schema,
@@ -107,6 +107,13 @@ class TestCreateAndExtend(TestCase):
 
         errors = list(validator.iter_errors("goodbye"))
         self.assertEqual(len(errors), 3)
+
+    def test_none(self):
+        schema = {"none": [{"message": "Whoops!"}]}
+        validator = self.Validator(schema)
+
+        errors = list(validator.iter_errors("hello"))
+        self.assertEqual(errors, [])
 
     def test_if_a_version_is_provided_it_is_registered(self):
         Validator = validators.create(

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -295,6 +295,7 @@ def create(
                     (self.VALIDATORS[k], k, v)
                     for k, v in applicable_validators(self.schema)
                     if k in self.VALIDATORS
+                    and self.VALIDATORS[k] is not None
                 ]
 
             # REMOVEME: Legacy ref resolution state management.
@@ -363,6 +364,7 @@ def create(
                     (self.VALIDATORS[k], k, v)
                     for k, v in applicable_validators(_schema)
                     if k in self.VALIDATORS
+                    and self.VALIDATORS[k] is not None
                 ]
             else:
                 _schema, validators = self.schema, self._validators


### PR DESCRIPTION
Fixes a regression in 4.22.0 where validators set to 'None' are not ignored, causing a `TypeError: 'NoneType' object is not callable` on validation. In version 4.21.1 and earlier, any validator set to None would be ignored.

<!-- readthedocs-preview python-jsonschema start -->
----
📚 Documentation preview 📚: https://python-jsonschema--1253.org.readthedocs.build/en/1253/

<!-- readthedocs-preview python-jsonschema end -->