### PR TITLE
Add validate hook

### DIFF
--- a/jsonschema/_typing.py
+++ b/jsonschema/_typing.py
@@ -27,3 +27,12 @@ ApplicableValidators = Callable[
     [referencing.jsonschema.Schema],
     Iterable[tuple[str, Any]],
 ]
+
+class ValidateHook(Protocol):
+    def __call__(
+        self,
+        is_valid: bool,
+        instance: Any,
+        schema: referencing.jsonschema.Schema,
+    ) -> None:
+        ...

--- a/jsonschema/protocols.py
+++ b/jsonschema/protocols.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 # therefore, only import at type-checking time (to avoid circular references),
 # but use `jsonschema` for any types which will otherwise not be resolvable
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable, Mapping, Sequence
 
     import referencing.jsonschema
 
@@ -101,6 +101,8 @@ class Validator(Protocol):
 
     #: A function which given a schema returns its ID.
     ID_OF: _typing.id_of
+
+    VALIDATE_HOOKS: ClassVar[Sequence]
 
     #: The schema that will be used to validate instances
     schema: Mapping | bool


### PR DESCRIPTION
Run user-defined hooks after validate.

One usage for me is clearing default keys when validate error in oneOf/anyOf. For example, if we use `extend_with_default` from docs to validate oneOf schema with default, such as following code:

```python
from jsonschema import Draft202012Validator, validators


def extend_with_default(validator_class):
    validate_properties = validator_class.VALIDATORS["properties"]

    def set_defaults(validator, properties, instance, schema):
        for property, subschema in properties.items():
            if "default" in subschema:
                instance.setdefault(property, subschema["default"])

        for error in validate_properties(
            validator, properties, instance, schema,
        ):
            yield error

    return validators.extend(
        validator_class, {"properties" : set_defaults},
    )


DefaultValidatingValidator = extend_with_default(Draft202012Validator)

obj = {'type': 'second_type'}
schema = {
    'oneOf': [
        {
            'properties': {
                'type': {'const': 'first_type'},
                'foo': {'default': 'bar'},
            },
            'additionalProperties': False,
        },
        {
            'properties': {
                'type': {'const': 'second_type'},
                'baz': {'default': 'qux'},
            },
            'additionalProperties': False,
        },
    ],
}

DefaultValidatingValidator(schema).validate(obj)
```

We will get an error like this:

```
jsonschema.exceptions.ValidationError: {'type': 'second_type', 'foo': 'bar', 'baz': 'qux'} is not valid under any of the given schemas

Failed validating 'oneOf' in schema:
    {'oneOf': [{'properties': {'type': {'const': 'first_type'},
                               'foo': {'default': 'bar'}},
                'additionalProperties': False},
               {'properties': {'type': {'const': 'second_type'},
                               'baz': {'default': 'qux'}},
                'additionalProperties': False}]}

On instance:
    {'type': 'second_type', 'foo': 'bar', 'baz': 'qux'}
```

That is because the "foo" was added when validate "first_type", making the schema of "second_type" invalid. With validate_hooks, we could add a hook to delete "foo" when validate error on "first_type". For example:

```python
def extend_with_default(validator_class):
    validate_properties = validator_class.VALIDATORS["properties"]
    default_keys = {}

    def set_defaults(validator, properties, instance, schema):
        dkeys = []
        for property, subschema in properties.items():
            if "default" in subschema and property not in instance:
                instance[property] = subschema["default"]
                dkeys.append(property)
        if dkeys:
            default_keys[(id(instance), id(schema))] = dkeys

        for error in validate_properties(
            validator, properties, instance, schema,
        ):
            yield error

    def validate_hook(is_valid, instance, schema):
        dkeys = default_keys.pop((id(instance), id(schema)), [])
        if not is_valid:
            for keys in dkeys:
                del instance[keys]

    return validators.extend(
        validator_class, {"properties" : set_defaults},
        validate_hooks = [validate_hook],
    )
```

<!-- readthedocs-preview python-jsonschema start -->
----
📚 Documentation preview 📚: https://python-jsonschema--1310.org.readthedocs.build/en/1310/

<!-- readthedocs-preview python-jsonschema end -->