### PR TITLE
Use decimal in multipleOf for the issue of accuracy

### DIFF
--- a/jsonschema/_keywords.py
+++ b/jsonschema/_keywords.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from fractions import Fraction
 import re
 
@@ -169,7 +170,7 @@ def multipleOf(validator, dB, instance, schema):
         return
 
     if isinstance(dB, float):
-        quotient = instance / dB
+        quotient = Decimal(str(instance)) / Decimal(str(dB))
         try:
             failed = int(quotient) != quotient
         except OverflowError:


### PR DESCRIPTION
A simple method to solve the accuracy problem in multipleOf keywords.

Javascript's implement https://github.com/tdegrunt/jsonschema/issues/187

<!-- readthedocs-preview python-jsonschema start -->
----
📚 Documentation preview 📚: https://python-jsonschema--1349.org.readthedocs.build/en/1349/

<!-- readthedocs-preview python-jsonschema end -->