### PR TITLE
1365 evaluation order

### DIFF
--- a/jsonschema/_keywords.py
+++ b/jsonschema/_keywords.py
@@ -28,7 +28,7 @@ class Keyword:
 
     def __init__(
             self,
-            func: typing.Optional[callable] = None, /,
+            func: typing.Optional[typing.Callable] = None, /,
             needs: typing.Optional[typing.Iterable[str]] = (),
     ):
         self.func = func
@@ -40,7 +40,7 @@ class Keyword:
         return self.func(validator, property, instance, schema)
 
 
-def keyword(func: typing.Optional[callable] = None, /, **kwargs):
+def keyword(func: typing.Optional[typing.Callable] = None, /, **kwargs):
     """
     Syntactic sugar to decorate a function as a keyword.
 

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -380,12 +380,12 @@ def create(
                 return
 
             todo = {k for _, k, _ in validators}
-            while validators:
-                dependant = []
+            while todo:
+                dependent = []
                 for validator, k, v in validators:
                     if isinstance(validator, _keywords.Keyword) \
                             and todo.intersection(validator.needs):
-                        dependant.append([validator, k, v])
+                        dependent.append([validator, k, v])
                         continue
                     errors = validator(self, v, instance, _schema) or ()
                     for error in errors:
@@ -401,9 +401,9 @@ def create(
                             error.schema_path.appendleft(k)
                         yield error
                     todo.discard(k)
-                if dependant == validators:
+                if dependent == validators:
                     raise ValueError("Circular dependency between keywords")
-                validators = dependant
+                validators = dependent
 
         def descend(
             self,


### PR DESCRIPTION
Closes #1365

## jsonschema/tests/test_validators.py
Adds a test method for the expected behavior, and reverences the issue being solved. The method is slightly longer than others to avoid `TestValidationErrorMessages.message_for`, which asserts that there be exactly one error.

## jsonschema/_keyword.py
The `Keyword` class can define additional tags/behavior for the implementation of the keyword. For now, I have only added a "needs" label, which names other keywords that it cannot be executed before. The name "needs" may be inaccurate, and I'd be happy to change it.

The `keyword` decorator makes it trivial to annotate a function to be used as a validator keyword.

`keyword` and `Keyword` are both optional and completely back-compatible. They would only be necessary for new behavior. There is no change to existing validator function behavior.

## jsonschema/validators.py
The only changed behavior is that the `iter_errors` evaluates `Keyword`s _after_ their `needs`. The logic is not as clean as I'd like, but is reasonably straightforward:
- Keep a memo of `todo` keywords.
- As keywords are evaluated, they are no longer `todo`.
- Any `Keyword` that `needs` a `todo` keyword is labeled `dependent` and skipped
- If _all_ attempted keywords were `dependent` of each other, there is a circular dependency and an error is raised.
- `dependent` keywords are re-attempted.

I'd be happy to add comments or a docstring to make the code more self-descriptive if necessary.


<!-- readthedocs-preview python-jsonschema start -->
----
📚 Documentation preview 📚: https://python-jsonschema--1366.org.readthedocs.build/en/1366/

<!-- readthedocs-preview python-jsonschema end -->