### PR TITLE
Fix: is_uuid returns False for non-string inputs and catches exception from UUID constructor

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -516,6 +516,9 @@ with suppress(ImportError):
 )
 def is_uuid(instance: object) -> bool:
     if not isinstance(instance, str):
-        return True
-    UUID(instance)
+        return False
+    try:
+        UUID(instance)
+    except:
+        return False
     return all(instance[position] == "-" for position in (8, 13, 18, 23))


### PR DESCRIPTION
Proposed fix for https://github.com/python-jsonschema/jsonschema/issues/1380

<!-- readthedocs-preview python-jsonschema start -->
----
📚 Documentation preview 📚: https://python-jsonschema--1381.org.readthedocs.build/en/1381/

<!-- readthedocs-preview python-jsonschema end -->