### PR TITLE
Unambiguously quote and escape properties in JSON path rendering

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -8,6 +8,7 @@ from pprint import pformat
 from textwrap import dedent, indent
 from typing import TYPE_CHECKING, Any, ClassVar
 import heapq
+import re
 import warnings
 
 from attrs import define
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
 
 WEAK_MATCHES: frozenset[str] = frozenset(["anyOf", "oneOf"])
 STRONG_MATCHES: frozenset[str] = frozenset()
+
+JSON_PATH_COMPATIBLE_PROPERTY_PATTERN = re.compile("^[a-zA-Z][a-zA-Z0-9_]*$")
 
 _unset = _utils.Unset()
 
@@ -152,8 +155,11 @@ class _Error(Exception):
         for elem in self.absolute_path:
             if isinstance(elem, int):
                 path += "[" + str(elem) + "]"
-            else:
+            elif JSON_PATH_COMPATIBLE_PROPERTY_PATTERN.match(elem):
                 path += "." + elem
+            else:
+                escaped_elem = elem.replace("\\", "\\\\").replace("'", r"\'")
+                path += "['" + escaped_elem + "']"
         return path
 
     def _set(

--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 WEAK_MATCHES: frozenset[str] = frozenset(["anyOf", "oneOf"])
 STRONG_MATCHES: frozenset[str] = frozenset()
 
-JSON_PATH_COMPATIBLE_PROPERTY_PATTERN = re.compile("^[a-zA-Z][a-zA-Z0-9_]*$")
+_JSON_PATH_COMPATIBLE_PROPERTY_PATTERN = re.compile("^[a-zA-Z][a-zA-Z0-9_]*$")
 
 _unset = _utils.Unset()
 
@@ -155,7 +155,7 @@ class _Error(Exception):
         for elem in self.absolute_path:
             if isinstance(elem, int):
                 path += "[" + str(elem) + "]"
-            elif JSON_PATH_COMPATIBLE_PROPERTY_PATTERN.match(elem):
+            elif _JSON_PATH_COMPATIBLE_PROPERTY_PATTERN.match(elem):
                 path += "." + elem
             else:
                 escaped_elem = elem.replace("\\", "\\\\").replace("'", r"\'")

--- a/jsonschema/tests/test_exceptions.py
+++ b/jsonschema/tests/test_exceptions.py
@@ -700,3 +700,122 @@ class TestHashable(TestCase):
     def test_hashable(self):
         {exceptions.ValidationError("")}
         {exceptions.SchemaError("")}
+
+
+class TestJsonPathRendering(TestCase):
+    def test_str(self):
+        e = exceptions.ValidationError(
+            path=["x"],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, "$.x")
+
+    def test_empty_str(self):
+        e = exceptions.ValidationError(
+            path=[""],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, "$['']")
+
+    def test_numeric_str(self):
+        e = exceptions.ValidationError(
+            path=["1"],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, "$['1']")
+
+    def test_period_str(self):
+        e = exceptions.ValidationError(
+            path=["."],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, "$['.']")
+
+    def test_single_quote_str(self):
+        e = exceptions.ValidationError(
+            path=["'"],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, r"$['\'']")
+
+    def test_space_str(self):
+        e = exceptions.ValidationError(
+            path=[" "],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, "$[' ']")
+
+    def test_backslash_str(self):
+        e = exceptions.ValidationError(
+            path=["\\"],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, r"$['\\']")
+
+    def test_backslash_single_quote(self):
+        e = exceptions.ValidationError(
+            path=[r"\'"],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, r"$['\\\'']")
+
+    def test_underscore(self):
+        e = exceptions.ValidationError(
+            path=["_"],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, r"$['_']")
+
+    def test_double_quote(self):
+        e = exceptions.ValidationError(
+            path=['"'],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, """$['"']""")
+
+    def test_hyphen(self):
+        e = exceptions.ValidationError(
+            path=["-"],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, "$['-']")
+
+    def test_json_path_injection(self):
+        e = exceptions.ValidationError(
+            path=["a[0]"],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, "$['a[0]']")
+
+    def test_open_bracket(self):
+        e = exceptions.ValidationError(
+            path=["["],
+            message="1",
+            validator="foo",
+            instance="i1",
+        )
+        self.assertEqual(e.json_path, "$['[']")

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,6 +61,7 @@ def tests(session, installable):
     env = dict(JSON_SCHEMA_TEST_SUITE=str(ROOT / "json"))
 
     session.install("virtue", installable)
+    session.install("jsonpath-ng", installable)
 
     if session.posargs and session.posargs[0] == "coverage":
         if len(session.posargs) > 1 and session.posargs[1] == "github":


### PR DESCRIPTION
This PR introduces the following change:

* Unambiguously quote and escape properties in JSON path rendering

Using the script from #1389, this is the new output with the changes in this branch:

```shell
$ python demo.py 
property=''             json_path="$['']"
property='['            json_path="$['[']"
property='.'            json_path="$['.']"
property='\\'           json_path="$['\\\\']"
property="'"            json_path="$['\\'']"
property=' '            json_path="$[' ']"
property='"'            json_path='$[\'"\']'
property='a[0]'         json_path="$['a[0]']"
```

Fixes #1389

<!-- readthedocs-preview python-jsonschema start -->
----
📚 Documentation preview 📚: https://python-jsonschema--1390.org.readthedocs.build/en/1390/

<!-- readthedocs-preview python-jsonschema end -->