### PR TITLE
validators: avoid `urllib.request` at import-time

### DIFF
--- a/jsonschema/benchmarks/import_benchmark.py
+++ b/jsonschema/benchmarks/import_benchmark.py
@@ -1,0 +1,31 @@
+"""
+A benchmark which measures the import time of jsonschema
+"""
+
+import subprocess
+import sys
+
+
+def import_time(loops):
+    total_us = 0
+    for _ in range(loops):
+        p = subprocess.run(  # noqa: S603 (arguments are static)
+            [sys.executable, "-X", "importtime", "-c", "import jsonschema"],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            check=True,
+        )
+
+        line = p.stderr.splitlines()[-1]
+        field = line.split(b"|")[-2].strip()
+        us = int(field)  # microseconds
+        total_us += us
+
+    # pyperf expects seconds
+    return total_us / 1_000_000.0
+
+if __name__ == "__main__":
+    from pyperf import Runner
+    runner = Runner()
+
+    runner.bench_time_func("Import time (cumulative)", import_time)

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -2379,11 +2379,9 @@ class TestRefResolver(TestCase):
             self.assertEqual(url, "http://bar")
             yield BytesIO(json.dumps(schema).encode("utf8"))
 
-        self.addCleanup(setattr, validators, "urlopen", validators.urlopen)
-        validators.urlopen = fake_urlopen
-
-        with self.resolver.resolving(ref) as resolved:
-            pass
+        with mock.patch("urllib.request.urlopen", new=fake_urlopen):  # noqa: SIM117
+            with self.resolver.resolving(ref) as resolved:
+                pass
         self.assertEqual(resolved, 12)
 
     def test_it_retrieves_local_refs_via_urlopen(self):

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -9,7 +9,6 @@ from functools import lru_cache
 from operator import methodcaller
 from typing import TYPE_CHECKING
 from urllib.parse import unquote, urldefrag, urljoin, urlsplit
-from urllib.request import urlopen
 from warnings import warn
 import contextlib
 import json
@@ -1225,6 +1224,7 @@ class _RefResolver:
             result = requests.get(uri).json()
         else:
             # Otherwise, pass off to urllib and assume utf-8
+            from urllib.request import urlopen
             with urlopen(uri) as url:  # noqa: S310
                 result = json.loads(url.read().decode("utf-8"))
 


### PR DESCRIPTION
The goal with this PR is to help reduce the time required to import the jsonschema module.

On my end calling:

`python -X importtime -c "import jsonschema"`

* Before: 216ms (main)
* After: 173ms (this PR)

----

<details>

<summary>importtime output (main)</summary>

```
import time: self [us] | cumulative | imported package
import time:       120 |        120 | winreg
import time:       163 |        163 |   _io
import time:        38 |         38 |   marshal
import time:       165 |        165 |   nt
import time:       628 |        992 | _frozen_importlib_external
import time:       930 |        930 |   time
import time:       266 |       1195 | zipimport
import time:        51 |         51 |     _codecs
import time:       543 |        593 |   codecs
import time:      1275 |       1275 |   encodings.aliases
import time:      2318 |       4184 | encodings
import time:       787 |        787 | encodings.utf_8
import time:       704 |        704 | encodings.cp1252
import time:        45 |         45 | _signal
import time:        29 |         29 |     _abc
import time:       168 |        196 |   abc
import time:       144 |        339 | io
import time:        48 |         48 |       _stat
import time:       123 |        170 |     stat
import time:       813 |        813 |     _collections_abc
import time:       102 |        102 |       genericpath
import time:        95 |         95 |       _winapi
import time:       298 |        495 |     ntpath
import time:       592 |       2069 |   os
import time:        84 |         84 |   _sitebuiltins
import time:        67 |         67 |   errno
import time:       748 |        748 |   encodings.utf_8_sig
import time:      2465 |       2465 |   _distutils_hack
import time:      1628 |       1628 |     pywin32_system32
import time:      2189 |       3817 |   pywin32_bootstrap
import time:       836 |        836 |   sitecustomize
import time:       771 |        771 |   usercustomize
import time:      2567 |      13420 | site
import time:      1231 |       1231 | linecache
import time:      1074 |       1074 |   warnings
import time:       959 |        959 |     __future__
import time:       114 |        114 |         itertools
import time:       830 |        830 |         keyword
import time:        70 |         70 |           _operator
import time:      1044 |       1114 |         operator
import time:       864 |        864 |         reprlib
import time:        83 |         83 |         _collections
import time:      1743 |       4746 |       collections
import time:        70 |         70 |         _functools
import time:      1553 |       1622 |       functools
import time:       920 |        920 |       types
import time:      1266 |       8553 |     contextlib
import time:        97 |         97 |       _datetime
import time:       858 |        954 |     datetime
import time:      1815 |       1815 |       enum
import time:      2468 |       2468 |       _uuid
import time:      1270 |       5553 |     uuid
import time:      1791 |       1791 |     ipaddress
import time:        66 |         66 |         _sre
import time:       736 |        736 |           re._constants
import time:       937 |       1672 |         re._parser
import time:       618 |        618 |         re._casefix
import time:      1174 |       3529 |       re._compiler
import time:       926 |        926 |       copyreg
import time:      1469 |       5923 |     re
import time:       165 |        165 |       _typing
import time:      2624 |       2788 |     typing
import time:       896 |        896 |               _weakrefset
import time:      1085 |       1981 |             weakref
import time:       907 |       2888 |           copy
import time:       756 |        756 |               _ast
import time:      1812 |       2568 |             ast
import time:        43 |         43 |                 _opcode
import time:      1036 |       1036 |                 _opcode_metadata
import time:      1028 |       2106 |               opcode
import time:      1895 |       4000 |             dis
import time:      1037 |       1037 |               importlib
import time:        96 |       1133 |             importlib.machinery
import time:       909 |        909 |               token
import time:        45 |         45 |               _tokenize
import time:      1425 |       2378 |             tokenize
import time:      2863 |      12941 |           inspect
import time:      1388 |      17215 |         dataclasses
import time:      1040 |      18255 |       pprint
import time:      1427 |       1427 |       textwrap
import time:        52 |         52 |         _heapq
import time:      1056 |       1107 |       heapq
import time:      2374 |       2374 |                 _wmi
import time:      1595 |       3969 |               platform
import time:      1292 |       1292 |               threading
import time:      1049 |       6310 |             attr._compat
import time:       980 |        980 |               unicodedata
import time:       646 |        646 |               attr._config
import time:       748 |        748 |                 attr.exceptions
import time:       686 |       1434 |               attr.setters
import time:      3014 |       6073 |             attr._make
import time:      1055 |      13437 |           attr.converters
import time:       730 |        730 |           attr.filters
import time:      3854 |       3854 |           attr.validators
import time:       771 |        771 |           attr._cmp
import time:       735 |        735 |           attr._funcs
import time:       664 |        664 |           attr._next_gen
import time:       951 |        951 |           attr._version_info
import time:      1724 |      22863 |         attr
import time:       901 |        901 |         attrs.converters
import time:       588 |        588 |         attrs.exceptions
import time:       874 |        874 |         attrs.filters
import time:       644 |        644 |         attrs.setters
import time:       612 |        612 |         attrs.validators
import time:      1571 |      28050 |       attrs
import time:       978 |        978 |               urllib
import time:        62 |         62 |               math
import time:      1687 |       2726 |             urllib.parse
import time:      1257 |       1257 |               rpds.rpds
import time:      1434 |       2691 |             rpds
import time:      2156 |       2156 |               _socket
import time:      2231 |       4387 |             typing_extensions
import time:       647 |        647 |               referencing._attrs
import time:      3096 |       3742 |             referencing.exceptions
import time:       901 |        901 |             referencing.typing
import time:      5604 |      20049 |           referencing._core
import time:      1286 |      21335 |         referencing
import time:        42 |      21376 |       referencing.exceptions
import time:       764 |        764 |       jsonschema._utils
import time:      1496 |      72473 |     jsonschema.exceptions
import time:       889 |        889 |     fqdn
import time:        42 |         42 |           _bisect
import time:       881 |        923 |         bisect
import time:      1135 |       1135 |         idna.idnadata
import time:       653 |        653 |         idna.intranges
import time:      1590 |       4299 |       idna.core
import time:       607 |        607 |       idna.package_data
import time:      1357 |       6263 |     idna
import time:       865 |        865 |     rfc3987
import time:       896 |        896 |     rfc3986_validator
import time:       852 |        852 |     rfc3987_syntax
import time:      1015 |       1015 |     rfc3339_validator
import time:       885 |        885 |     webcolors
import time:       853 |        853 |     jsonpointer
import time:       851 |        851 |     uri_template
import time:       844 |        844 |     isoduration
import time:      1946 |     115145 |   jsonschema._format
import time:      1068 |       1068 |     numbers
import time:      1035 |       2103 |   jsonschema._types
import time:        65 |         65 |           _struct
import time:       872 |        937 |         struct
import time:        79 |         79 |         binascii
import time:       982 |       1997 |       base64
import time:      1173 |       1173 |       email
import time:      3724 |       3724 |         _hashlib
import time:        55 |         55 |         _blake2
import time:       960 |       4738 |       hashlib
import time:      1402 |       1402 |         http
import time:       838 |        838 |             email.errors
import time:        37 |         37 |                     _string
import time:      1274 |       1311 |                   string
import time:       854 |       2165 |                 email.quoprimime
import time:       702 |        702 |                 email.base64mime
import time:       840 |        840 |                     quopri
import time:       692 |       1531 |                   email.encoders
import time:       795 |       2326 |                 email.charset
import time:      1122 |       6313 |               email.header
import time:       716 |        716 |                 email._parseaddr
import time:       885 |       1601 |               email.utils
import time:       795 |       8708 |             email._policybase
import time:      1060 |      10606 |           email.feedparser
import time:      1061 |      11666 |         email.parser
import time:       733 |        733 |           email._encoded_words
import time:       654 |        654 |           email.iterators
import time:      1023 |       2409 |         email.message
import time:      1085 |       1085 |             select
import time:      1184 |       2269 |           selectors
import time:      1691 |       3959 |         socket
import time:      2235 |       2235 |           _ssl
import time:      2482 |       4716 |         ssl
import time:      1969 |      26120 |       http.client
import time:      1017 |       1017 |               posix
import time:       874 |        874 |               posix
import time:       236 |       2125 |             posixpath
import time:       933 |       3058 |           fnmatch
import time:        89 |         89 |           zlib
import time:       877 |        877 |             _compression
import time:       971 |        971 |             _bz2
import time:      1103 |       2950 |           bz2
import time:      1097 |       1097 |             _lzma
import time:       922 |       2019 |           lzma
import time:      1412 |       9527 |         shutil
import time:        42 |         42 |           _random
import time:      1216 |       1258 |         random
import time:      1172 |      11956 |       tempfile
import time:       690 |        690 |         urllib.response
import time:       756 |       1445 |       urllib.error
import time:       904 |        904 |       nturl2path
import time:      2071 |      50400 |     urllib.request
import time:        67 |         67 |           _json
import time:       962 |       1028 |         json.scanner
import time:      1305 |       2333 |       json.decoder
import time:       851 |        851 |       json.encoder
import time:      1092 |       4275 |     json
import time:      1536 |       1536 |       referencing.jsonschema
import time:      1034 |       1034 |                 glob
import time:      1318 |       2351 |               pathlib._abc
import time:       896 |        896 |                 pwd
import time:       949 |        949 |                 grp
import time:      1188 |       3033 |               pathlib._local
import time:      1045 |       6427 |             pathlib
import time:       935 |        935 |             importlib.resources.abc
import time:      1189 |       8551 |           importlib.resources._common
import time:       634 |        634 |           importlib.resources._functional
import time:      1135 |      10319 |         importlib.resources
import time:      1128 |      11447 |       jsonschema_specifications._core
import time:       726 |        726 |       importlib.resources._adapters
import time:       644 |        644 |               importlib._abc
import time:       199 |        843 |             importlib.util
import time:       919 |        919 |               zipfile._path.glob
import time:      1398 |       2317 |             zipfile._path
import time:      1632 |       4790 |           zipfile
import time:       656 |        656 |           importlib.resources._itertools
import time:       802 |       6248 |         importlib.resources.readers
import time:       766 |       7014 |       importlib.readers
import time:     10160 |      30881 |     jsonschema_specifications
import time:      1251 |       1251 |           _decimal
import time:       826 |       2076 |         decimal
import time:      1898 |       3974 |       fractions
import time:       878 |       4852 |     jsonschema._keywords
import time:       821 |        821 |     jsonschema._legacy_keywords
import time:       704 |        704 |       jsonschema.protocols
import time:       753 |       1456 |     jsonschema._typing
import time:      4052 |      96734 |   jsonschema.validators
import time:      1871 |     216925 | jsonschema
```

</details>

<details>

<summary>importtime output (this PR)</summary>

```
import time: self [us] | cumulative | imported package
import time:       111 |        111 | winreg
import time:       159 |        159 |   _io
import time:        36 |         36 |   marshal
import time:       171 |        171 |   nt
import time:       587 |        952 | _frozen_importlib_external
import time:       912 |        912 |   time
import time:       249 |       1161 | zipimport
import time:        48 |         48 |     _codecs
import time:       456 |        504 |   codecs
import time:      1344 |       1344 |   encodings.aliases
import time:      2273 |       4119 | encodings
import time:       682 |        682 | encodings.utf_8
import time:       657 |        657 | encodings.cp1252
import time:        42 |         42 | _signal
import time:        28 |         28 |     _abc
import time:       163 |        191 |   abc
import time:       140 |        330 | io
import time:        48 |         48 |       _stat
import time:       128 |        176 |     stat
import time:       715 |        715 |     _collections_abc
import time:        79 |         79 |       genericpath
import time:       106 |        106 |       _winapi
import time:       280 |        464 |     ntpath
import time:       610 |       1963 |   os
import time:        89 |         89 |   _sitebuiltins
import time:        56 |         56 |   errno
import time:       746 |        746 |   encodings.utf_8_sig
import time:      2388 |       2388 |   _distutils_hack
import time:      1596 |       1596 |     pywin32_system32
import time:      2087 |       3683 |   pywin32_bootstrap
import time:       885 |        885 |   sitecustomize
import time:       756 |        756 |   usercustomize
import time:      2694 |      13257 | site
import time:      1267 |       1267 | linecache
import time:       974 |        974 |   warnings
import time:       837 |        837 |     __future__
import time:       107 |        107 |         itertools
import time:       955 |        955 |         keyword
import time:        69 |         69 |           _operator
import time:       979 |       1048 |         operator
import time:       850 |        850 |         reprlib
import time:        76 |         76 |         _collections
import time:      1716 |       4750 |       collections
import time:        56 |         56 |         _functools
import time:      1192 |       1247 |       functools
import time:       963 |        963 |       types
import time:      1207 |       8166 |     contextlib
import time:        96 |         96 |       _datetime
import time:       845 |        941 |     datetime
import time:      1932 |       1932 |       enum
import time:      2034 |       2034 |       _uuid
import time:      1264 |       5229 |     uuid
import time:      1877 |       1877 |     ipaddress
import time:        64 |         64 |         _sre
import time:       731 |        731 |           re._constants
import time:       904 |       1635 |         re._parser
import time:       605 |        605 |         re._casefix
import time:      1140 |       3443 |       re._compiler
import time:       823 |        823 |       copyreg
import time:      1315 |       5580 |     re
import time:       162 |        162 |       _typing
import time:      2468 |       2630 |     typing
import time:       885 |        885 |               _weakrefset
import time:      1049 |       1934 |             weakref
import time:       899 |       2832 |           copy
import time:       813 |        813 |               _ast
import time:      1700 |       2512 |             ast
import time:        42 |         42 |                 _opcode
import time:       989 |        989 |                 _opcode_metadata
import time:      1231 |       2261 |               opcode
import time:      1580 |       3840 |             dis
import time:       969 |        969 |               importlib
import time:        90 |       1059 |             importlib.machinery
import time:       896 |        896 |               token
import time:        53 |         53 |               _tokenize
import time:      1463 |       2411 |             tokenize
import time:      2525 |      12346 |           inspect
import time:      1229 |      16406 |         dataclasses
import time:       956 |      17362 |       pprint
import time:      1493 |       1493 |       textwrap
import time:        50 |         50 |         _heapq
import time:       912 |        962 |       heapq
import time:      2469 |       2469 |                 _wmi
import time:      1475 |       3943 |               platform
import time:      1162 |       1162 |               threading
import time:      1006 |       6110 |             attr._compat
import time:       964 |        964 |               unicodedata
import time:       811 |        811 |               attr._config
import time:       702 |        702 |                 attr.exceptions
import time:       690 |       1391 |               attr.setters
import time:      3050 |       6216 |             attr._make
import time:      1010 |      13335 |           attr.converters
import time:       651 |        651 |           attr.filters
import time:      3795 |       3795 |           attr.validators
import time:       790 |        790 |           attr._cmp
import time:       741 |        741 |           attr._funcs
import time:       654 |        654 |           attr._next_gen
import time:       958 |        958 |           attr._version_info
import time:      1587 |      22508 |         attr
import time:       896 |        896 |         attrs.converters
import time:       701 |        701 |         attrs.exceptions
import time:       606 |        606 |         attrs.filters
import time:       591 |        591 |         attrs.setters
import time:       580 |        580 |         attrs.validators
import time:      1517 |      27395 |       attrs
import time:       922 |        922 |               urllib
import time:        62 |         62 |               math
import time:      1706 |       2690 |             urllib.parse
import time:      1192 |       1192 |               rpds.rpds
import time:      1314 |       2506 |             rpds
import time:      2024 |       2024 |               _socket
import time:      2329 |       4352 |             typing_extensions
import time:       639 |        639 |               referencing._attrs
import time:      2834 |       3473 |             referencing.exceptions
import time:       749 |        749 |             referencing.typing
import time:      5293 |      19060 |           referencing._core
import time:      1266 |      20325 |         referencing
import time:        38 |      20363 |       referencing.exceptions
import time:       795 |        795 |       jsonschema._utils
import time:      1312 |      69680 |     jsonschema.exceptions
import time:       898 |        898 |     fqdn
import time:        36 |         36 |           _bisect
import time:       813 |        848 |         bisect
import time:      1419 |       1419 |         idna.idnadata
import time:       655 |        655 |         idna.intranges
import time:      1409 |       4330 |       idna.core
import time:       629 |        629 |       idna.package_data
import time:      1278 |       6236 |     idna
import time:       837 |        837 |     rfc3987
import time:       828 |        828 |     rfc3986_validator
import time:       930 |        930 |     rfc3987_syntax
import time:       823 |        823 |     rfc3339_validator
import time:       841 |        841 |     webcolors
import time:       819 |        819 |     jsonpointer
import time:       815 |        815 |     uri_template
import time:       815 |        815 |     isoduration
import time:      1819 |     110590 |   jsonschema._format
import time:      1043 |       1043 |     numbers
import time:      1072 |       2114 |   jsonschema._types
import time:        60 |         60 |           _json
import time:       871 |        931 |         json.scanner
import time:      1173 |       2103 |       json.decoder
import time:       835 |        835 |       json.encoder
import time:      1229 |       4166 |     json
import time:      1472 |       1472 |       referencing.jsonschema
import time:       849 |        849 |                       posix
import time:      1024 |       1024 |                       posix
import time:       190 |       2062 |                     posixpath
import time:      1009 |       3070 |                   fnmatch
import time:      1054 |       4123 |                 glob
import time:      1238 |       5361 |               pathlib._abc
import time:       851 |        851 |                 pwd
import time:      1015 |       1015 |                 grp
import time:      1056 |       2921 |               pathlib._local
import time:       966 |       9247 |             pathlib
import time:        68 |         68 |                 zlib
import time:       846 |        846 |                   _compression
import time:      1018 |       1018 |                   _bz2
import time:       935 |       2799 |                 bz2
import time:       930 |        930 |                   _lzma
import time:      1042 |       1971 |                 lzma
import time:      1401 |       6238 |               shutil
import time:        41 |         41 |                 _random
import time:      1129 |       1169 |               random
import time:      1108 |       8514 |             tempfile
import time:       947 |        947 |             importlib.resources.abc
import time:      1150 |      19856 |           importlib.resources._common
import time:       712 |        712 |           importlib.resources._functional
import time:      1320 |      21888 |         importlib.resources
import time:      1096 |      22983 |       jsonschema_specifications._core
import time:       744 |        744 |       importlib.resources._adapters
import time:        62 |         62 |             binascii
import time:       692 |        692 |               importlib._abc
import time:       215 |        907 |             importlib.util
import time:        59 |         59 |               _struct
import time:       938 |        997 |             struct
import time:       953 |        953 |               zipfile._path.glob
import time:      1230 |       2182 |             zipfile._path
import time:      1525 |       5672 |           zipfile
import time:       611 |        611 |           importlib.resources._itertools
import time:       819 |       7102 |         importlib.resources.readers
import time:       643 |       7745 |       importlib.readers
import time:      9797 |      42739 |     jsonschema_specifications
import time:      1253 |       1253 |           _decimal
import time:       814 |       2066 |         decimal
import time:      1975 |       4041 |       fractions
import time:       757 |       4798 |     jsonschema._keywords
import time:       756 |        756 |     jsonschema._legacy_keywords
import time:       692 |        692 |       jsonschema.protocols
import time:       793 |       1485 |     jsonschema._typing
import time:      4321 |      58261 |   jsonschema.validators
import time:      1842 |     173778 | jsonschema
```

</details>





<!-- readthedocs-preview python-jsonschema start -->
----
📚 Documentation preview 📚: https://python-jsonschema--1416.org.readthedocs.build/en/1416/

<!-- readthedocs-preview python-jsonschema end -->