### PR TITLE
Document `uuid` format

### DIFF
--- a/docs/validate.rst
+++ b/docs/validate.rst
@@ -237,6 +237,7 @@ Checker                    Notes
 ``uri``                    requires rfc3987_ or rfc3986-validator_
 ``uri-reference``          requires rfc3987_ or rfc3986-validator_
 ``uri-template``           requires uri-template_
+``uuid``
 =========================  ====================
 
 


### PR DESCRIPTION
People keep being confused about whether this is supported or not (including me): https://github.com/python-jsonschema/jsonschema/issues?q=is%3Aissue%20state%3Aclosed%20uuid.

It is supported but the documentation mentions `uuid` nowhere, making it look like it's not supported.