### PR TITLE
docs: Fix misleading comment in relevance function

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -415,7 +415,7 @@ def by_relevance(weak=WEAK_MATCHES, strong=STRONG_MATCHES):
     def relevance(error):
         validator = error.validator
         return (                        # prefer errors which are ...
-            -len(error.path),           # 'higher up' (shorter path) and thereby more general
+            -len(error.path),           # shorter path thereby more general
             error.path,                 # earlier (for sibling errors)
             validator not in weak,      # for a non-low-priority keyword
             validator in strong,        # for a high priority keyword


### PR DESCRIPTION
The comment in the relevance() function incorrectly suggested that -len(error.path) prefers 'deeper' errors. 
In reality, this logic prioritizes errors with shorter paths (higher up in the instance).

Updated the comment to accurately reflect that shorter paths are preferred for general validation errors, which aligns with the actual code behavior.

Closes https://github.com/python-jsonschema/jsonschema/issues/1325