### PR TITLE
Fix multipleOf with integer-valued float for large integers

### DIFF
--- a/jsonschema/_keywords.py
+++ b/jsonschema/_keywords.py
@@ -168,6 +168,12 @@ def multipleOf(validator, dB, instance, schema):
     if not validator.is_type(instance, "number"):
         return
 
+    # JSON Schema: numbers with zero fractional parts are integers.
+    # Convert integer-valued floats (e.g. 11.0) to int to avoid
+    # floating-point precision loss with large instances.
+    if isinstance(dB, float) and dB.is_integer():
+        dB = int(dB)
+
     if isinstance(dB, float):
         quotient = instance / dB
         try:

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -501,6 +501,23 @@ class TestValidationErrorMessages(TestCase):
         )
         self.assertEqual(message, "3 is not a multiple of 2")
 
+    def test_multipleOf_integer_valued_float(self):
+        """Integer-valued floats like 11.0 should behave like integers (#1159).
+
+        Large integers beyond 2**53 lose precision in float division,
+        so multipleOf with an integer-valued float must use integer
+        arithmetic to avoid false negatives.
+        """
+        instance = 9007199254740995  # 2**53 + 3, a multiple of 11
+        # With integer divisor this passes
+        validators.Draft202012Validator(
+            {"type": "integer", "multipleOf": 11},
+        ).validate(instance)
+        # With integer-valued float divisor this should also pass
+        validators.Draft202012Validator(
+            {"type": "integer", "multipleOf": 11.0},
+        ).validate(instance)
+
     def test_minItems(self):
         message = self.message_for(instance=[], schema={"minItems": 2})
         self.assertEqual(message, "[] is too short")


### PR DESCRIPTION
## Summary

When `multipleOf` is an integer-valued float (e.g. `11.0`), the validator uses float division, which loses precision for instances beyond `2**53`. This causes false negatives: `9007199254740995` is a multiple of `11`, but `9007199254740995 / 11.0` loses precision and the check fails.

The fix converts integer-valued floats to `int` before performing the divisibility check, using `float.is_integer()`. This ensures that `multipleOf: 11.0` behaves identically to `multipleOf: 11`, per the JSON Schema spec which states that numbers with zero fractional parts are integers.

Non-integer floats (e.g. `0.5`) are unaffected — the `isinstance(dB, float)` branch still handles them.

Fixes #1159.