### PR TITLE
fix(exceptions): count duplicate-validator errors in ErrorTree

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -321,6 +321,7 @@ class ErrorTree:
 
     def __init__(self, errors: Iterable[ValidationError] = ()):
         self.errors: MutableMapping[str, ValidationError] = {}
+        self._all_errors: list[ValidationError] = []
         self._contents: Mapping[str, ErrorTree] = defaultdict(self.__class__)
 
         for error in errors:
@@ -328,6 +329,7 @@ class ErrorTree:
             for element in error.path:
                 container = container[element]
             container.errors[error.validator] = error
+            container._all_errors.append(error)
 
             container._instance = error.instance
 
@@ -390,7 +392,7 @@ class ErrorTree:
         The total number of errors in the entire tree, including children.
         """
         child_errors = sum(len(tree) for _, tree in self._contents.items())
-        return len(self.errors) + child_errors
+        return len(self._all_errors) + child_errors
 
 
 def by_relevance(weak=WEAK_MATCHES, strong=STRONG_MATCHES):

--- a/jsonschema/tests/test_exceptions.py
+++ b/jsonschema/tests/test_exceptions.py
@@ -394,6 +394,17 @@ class TestErrorTree(TestCase):
         tree = exceptions.ErrorTree(errors)
         self.assertEqual(tree.total_errors, 8)
 
+    def test_total_errors_counts_duplicate_validators(self):
+        # Regression test for #442: multiple errors at the same path
+        # sharing the same validator keyword should all be counted.
+        errors = [
+            exceptions.ValidationError("first", validator="type"),
+            exceptions.ValidationError("second", validator="type"),
+            exceptions.ValidationError("third", validator="type"),
+        ]
+        tree = exceptions.ErrorTree(errors)
+        self.assertEqual(tree.total_errors, 3)
+
     def test_it_contains_an_item_if_the_item_had_an_error(self):
         errors = [exceptions.ValidationError("a message", path=["bar"])]
         tree = exceptions.ErrorTree(errors)


### PR DESCRIPTION
Closes #442

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
python-jsonschema/jsonschema

## Issue
https://github.com/python-jsonschema/jsonschema/issues/442

## Root cause
`ErrorTree.errors` is a `dict` keyed by `error.validator`, so when multiple
`ValidationError`s at the same path share the same validator keyword (e.g.
several "type" failures), later ones overwrite earlier ones. Because
`total_errors` was computed as `len(self.errors) + child_errors`, those
collapsed errors were silently undercounted.

## Fix
Keep the per-validator `errors` dict for backward compatibility, but also
append every incoming error to a new internal `_all_errors` list and use
`len(self._all_errors)` in `total_errors`. Surgical change in
`jsonschema/exceptions.py` (`ErrorTree.__init__` and `total_errors`).

## Regression test
`jsonschema/tests/test_exceptions.py::TestErrorTree::test_total_errors_counts_duplicate_validators`
asserts that an `ErrorTree` built from three `ValidationError`s sharing
`validator="type"` reports `total_errors == 3` (was 1 before the fix).

## Risk
low

## Verification
Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest jsonschema/tests/test_exceptions.py -q` — 60 passed, 0 failed.
