### PR TITLE
Handle integer-valued float multipleOf divisors exactly

### DIFF
--- a/jsonschema/_keywords.py
+++ b/jsonschema/_keywords.py
@@ -169,21 +169,24 @@ def multipleOf(validator, dB, instance, schema):
         return
 
     if isinstance(dB, float):
-        quotient = instance / dB
-        try:
-            failed = int(quotient) != quotient
-        except OverflowError:
-            # When `instance` is large and `dB` is less than one,
-            # quotient can overflow to infinity; and then casting to int
-            # raises an error.
-            #
-            # In this case we fall back to Fraction logic, which is
-            # exact and cannot overflow.  The performance is also
-            # acceptable: we try the fast all-float option first, and
-            # we know that fraction(dB) can have at most a few hundred
-            # digits in each part.  The worst-case slowdown is therefore
-            # for already-slow enormous integers or Decimals.
-            failed = (Fraction(instance) / Fraction(dB)).denominator != 1
+        if dB.is_integer():
+            failed = instance % int(dB)
+        else:
+            quotient = instance / dB
+            try:
+                failed = int(quotient) != quotient
+            except OverflowError:
+                # When `instance` is large and `dB` is less than one,
+                # quotient can overflow to infinity; and then casting to int
+                # raises an error.
+                #
+                # In this case we fall back to Fraction logic, which is
+                # exact and cannot overflow.  The performance is also
+                # acceptable: we try the fast all-float option first, and
+                # we know that fraction(dB) can have at most a few hundred
+                # digits in each part.  The worst-case slowdown is therefore
+                # for already-slow enormous integers or Decimals.
+                failed = (Fraction(instance) / Fraction(dB)).denominator != 1
     else:
         failed = instance % dB
 

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1667,6 +1667,11 @@ class ValidatorTestMixin(MetaSchemaTestsMixin):
         schema, instance = self.invalid
         self.assertFalse(self.Validator(schema).is_valid(instance))
 
+    def test_large_integer_multiple_of_integer_valued_float(self):
+        schema = {"type": "integer", "multipleOf": 11.0}
+        instance = 9007199254740995
+        self.assertTrue(self.Validator(schema).is_valid(instance))
+
     def test_non_existent_properties_are_ignored(self):
         self.Validator({object(): object()}).validate(instance=object())
 


### PR DESCRIPTION
## Summary
- treat integer-valued float `multipleOf` divisors with exact integer modulo logic
- keep the existing float fast path and Fraction fallback for non-integer float divisors
- add regression coverage for large integers across validator drafts

## Reproduction
```python
from jsonschema import validate

validate(9007199254740995, {"type": "integer", "multipleOf": 11})
validate(9007199254740995, {"type": "integer", "multipleOf": 11.0})
```

Before this change, the second validation incorrectly failed.

Closes #1159

## Testing
- `uv run python -m unittest jsonschema.tests.test_validators.TestDraft3Validator.test_large_integer_multiple_of_integer_valued_float jsonschema.tests.test_validators.TestDraft4Validator.test_large_integer_multiple_of_integer_valued_float jsonschema.tests.test_validators.TestDraft6Validator.test_large_integer_multiple_of_integer_valued_float jsonschema.tests.test_validators.TestDraft7Validator.test_large_integer_multiple_of_integer_valued_float jsonschema.tests.test_validators.TestDraft201909Validator.test_large_integer_multiple_of_integer_valued_float jsonschema.tests.test_validators.TestDraft202012Validator.test_large_integer_multiple_of_integer_valued_float`
- `uv run python -m unittest jsonschema.tests.test_validators`