### PR TITLE
fix(exceptions): prevent ErrorTree.__getitem__ from mutating _contents

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -326,7 +326,7 @@ class ErrorTree:
         for error in errors:
             container = self
             for element in error.path:
-                container = container[element]
+                container = container._contents[element]
             container.errors[error.validator] = error
 
             container._instance = error.instance
@@ -348,6 +348,8 @@ class ErrorTree:
         """
         if self._instance is not _unset and index not in self:
             self._instance[index]
+        if index not in self._contents:
+            return self.__class__()
         return self._contents[index]
 
     def __setitem__(self, index: str | int, value: ErrorTree):


### PR DESCRIPTION
Accessing `tree[index]` on an index with no errors was silently inserting an empty `ErrorTree` into `_contents` via `defaultdict`, causing subsequent `__iter__` and `__contains__` calls to report phantom entries (fixes #1328).

The fix has two parts: `__init__` now navigates via `_contents[element]` directly (bypassing `__getitem__`) to build the tree, and `__getitem__` returns a fresh detached empty tree when the index is absent rather than triggering the defaultdict factory.

To verify: construct a tree with errors only at index 0, access `tree[1]`, then confirm `list(tree) == [0]` and `1 not in tree`.