### PR TITLE
Avoid mutating ErrorTree on missing child lookup

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -3,7 +3,7 @@ Validation errors, and some surrounding helpers.
 """
 from __future__ import annotations
 
-from collections import defaultdict, deque
+from collections import deque
 from pprint import pformat
 from textwrap import dedent, indent
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -321,12 +321,15 @@ class ErrorTree:
 
     def __init__(self, errors: Iterable[ValidationError] = ()):
         self.errors: MutableMapping[str, ValidationError] = {}
-        self._contents: Mapping[str, ErrorTree] = defaultdict(self.__class__)
+        self._contents: MutableMapping[str | int, ErrorTree] = {}
 
         for error in errors:
             container = self
             for element in error.path:
-                container = container[element]
+                container = container._contents.setdefault(
+                    element,
+                    self.__class__(),
+                )
             container.errors[error.validator] = error
 
             container._instance = error.instance
@@ -346,9 +349,15 @@ class ErrorTree:
         by ``instance.__getitem__`` will be propagated (usually this is
         some subclass of `LookupError`.
         """
-        if self._instance is not _unset and index not in self:
+        try:
+            return self._contents[index]
+        except KeyError:
+            pass
+
+        if self._instance is not _unset:
             self._instance[index]
-        return self._contents[index]
+
+        return self.__class__()
 
     def __setitem__(self, index: str | int, value: ErrorTree):
         """

--- a/jsonschema/tests/test_exceptions.py
+++ b/jsonschema/tests/test_exceptions.py
@@ -404,6 +404,23 @@ class TestErrorTree(TestCase):
         tree = exceptions.ErrorTree(errors)
         self.assertNotIn("foo", tree)
 
+    def test_getting_item_without_errors_does_not_create_a_subtree(self):
+        schema = {
+            "type": "array",
+            "items": {"type": "number", "enum": [1, 2, 3]},
+            "minItems": 3,
+        }
+        instance = ["spam", 2]
+        tree = exceptions.ErrorTree(
+            _LATEST_VERSION(schema).iter_errors(instance),
+        )
+
+        self.assertEqual(list(tree), [0])
+        self.assertNotIn(1, tree)
+        self.assertIsInstance(tree[1], exceptions.ErrorTree)
+        self.assertEqual(list(tree), [0])
+        self.assertNotIn(1, tree)
+
     def test_keywords_that_failed_appear_in_errors_dict(self):
         error = exceptions.ValidationError("a message", validator="foo")
         tree = exceptions.ErrorTree([error])


### PR DESCRIPTION
Fixes #1328.

This replaces `ErrorTree`'s internal `defaultdict` child storage with an explicit dictionary so reading a valid child with no errors does not persist an empty subtree. Existing error paths are still populated during construction, and invalid indices still propagate the underlying instance lookup error.

Tests:
- `uv run --group test python -m unittest jsonschema.tests.test_exceptions`
- `PYTHONUTF8=1 JSON_SCHEMA_TEST_SUITE=json uv run --group test virtue jsonschema`
- `uv run --with ruff ruff check jsonschema\exceptions.py jsonschema\tests\test_exceptions.py`
