### PR TITLE
Fix relative-json-pointer rejecting multi-digit integers containing a zero

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -488,8 +488,11 @@ with suppress(ImportError):
         non_negative_integer, rest = [], ""
         for i, character in enumerate(instance):
             if character.isdigit():
-                # digits with a leading "0" are not allowed
-                if i > 0 and int(instance[i - 1]) == 0:
+                # a leading "0" is not allowed: "0" by itself is valid, but a
+                # multi-digit integer may not start with "0" (e.g. "01"). Only
+                # the single accumulated "0" followed by another digit is a
+                # leading zero -- "100"/"205" are fine.
+                if non_negative_integer == ["0"]:
                     return False
 
                 non_negative_integer.append(character)

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -80,6 +80,25 @@ class TestFormatChecker(TestCase):
         with self.assertRaises(FormatError):
             checker.check(instance="not-an-ipv4", format="ipv4")
 
+    def test_relative_json_pointer_allows_multidigit_integers(self):
+        checker = FormatChecker()
+        if "relative-json-pointer" not in checker.checkers:
+            self.skipTest("jsonpointer is not available")
+
+        # Only a *leading* zero is disallowed; a multi-digit integer with an
+        # internal or trailing zero is valid.
+        valids = ("0", "1", "120", "100", "205", "1000", "100/foo", "100#")
+        for valid in valids:
+            self.assertTrue(
+                checker.conforms(valid, "relative-json-pointer"),
+                msg=f"{valid!r} should be a valid relative-json-pointer",
+            )
+        for invalid in ("01", "00", "007", "01/a", "01#"):
+            self.assertFalse(
+                checker.conforms(invalid, "relative-json-pointer"),
+                msg=f"{invalid!r} should not be a valid relative-json-pointer",
+            )
+
     def test_repr(self):
         checker = FormatChecker(formats=())
         checker.checks("foo")(lambda thing: True)  # pragma: no cover


### PR DESCRIPTION
The `relative-json-pointer` format checker rejects valid pointers whose
non-negative-integer prefix contains a `0` after the first digit.

The leading-zero guard checked the **previous** character rather than the first
digit:

```python
# jsonschema/_format.py, is_relative_json_pointer
if i > 0 and int(instance[i - 1]) == 0:
    return False
```

So any integer prefix with a `0` followed by another digit was wrongly rejected,
while the bundled conformance suite only exercises `"120"` (where the `0` is
last) and so never caught it:

```python
>>> from jsonschema import FormatChecker
>>> FormatChecker().conforms("100", "relative-json-pointer")
False        # should be True
>>> FormatChecker().conforms("100/foo", "relative-json-pointer")
False        # should be True
```

Per draft-handrews-relative-json-pointer-01 §3, only a **leading** zero is
forbidden: `"0"` by itself is valid, `"01"` is not, and `"100"` / `"205"` /
`"1000"` are valid.

## Fix

Reject only when the accumulated integer is exactly `"0"` and another digit
follows (i.e. a genuine leading zero), instead of rejecting any digit that
follows a `0`.

## Tests

Added `test_relative_json_pointer_allows_multidigit_integers` to
`jsonschema/tests/test_format.py`: `0/1/120/100/205/1000/100/foo/100#` are valid
and `01/00/007/01/a/01#` are not. It fails on `main` and passes with the fix.
Full `test_format.py` + the JSON Schema test suite stay green (7628 passed);
`ruff` clean.

(Happy to add a `CHANGELOG.rst` entry if you'd like.)
