### PR TITLE
Report an out-of-range duration as invalid instead of erroring

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from contextlib import suppress
 from datetime import date, datetime
 from uuid import UUID
+import decimal
 import ipaddress
 import re
 import typing
@@ -524,7 +525,13 @@ with suppress(ImportError):
     @_checks_drafts(
         draft201909="duration",
         draft202012="duration",
-        raises=isoduration.DurationParsingException,
+        # isoduration parses components with decimal.Decimal, which raises a
+        # decimal.DecimalException (e.g. Overflow) rather than a
+        # DurationParsingException on extreme values such as "P1E1000000D".
+        raises=(
+            isoduration.DurationParsingException,
+            decimal.DecimalException,
+        ),
     )
     def is_duration(instance: object) -> bool:
         if not isinstance(instance, str):

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -89,3 +89,15 @@ class TestFormatChecker(TestCase):
             repr(checker),
             "<FormatChecker checkers=['bar', 'baz', 'foo']>",
         )
+
+    def test_duration_with_overflowing_exponent_is_invalid(self):
+        # A duration whose exponent overflows decimal used to raise an uncaught
+        # decimal.Overflow instead of reporting the instance as invalid.
+        # See https://github.com/python-jsonschema/jsonschema/issues/1511
+        try:
+            import isoduration  # noqa: F401
+        except ImportError:
+            self.skipTest("isoduration is not installed")
+        checker = FormatChecker()
+        with self.assertRaises(FormatError):
+            checker.check(instance="P1E1000000D", format="duration")


### PR DESCRIPTION
Fixes #1511.

The `duration` format checker registers `raises=isoduration.DurationParsingException`, but `isoduration` parses components with `decimal.Decimal`, so an extreme value like `"P1E1000000D"` raises `decimal.Overflow` (a `decimal.DecimalException` / `ArithmeticError`) instead. That escaped the format checker uncaught rather than the instance being reported invalid.

This adds `decimal.DecimalException` to the `raises` tuple, so such an instance is treated as an invalid duration (the checker returns `False` / raises `FormatError`) rather than propagating a `decimal` error.

Added a regression test in `test_format.py` (skipped when `isoduration` isn't installed). `ruff` and the format test suite pass. Happy to add a CHANGELOG entry if you'd like one.