### PR TITLE
Fix is_duration raising uncaught decimal.Overflow on large exponents

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 from datetime import date, datetime
+from decimal import Overflow
 from uuid import UUID
 import ipaddress
 import re
@@ -524,7 +525,7 @@ with suppress(ImportError):
     @_checks_drafts(
         draft201909="duration",
         draft202012="duration",
-        raises=isoduration.DurationParsingException,
+        raises=(isoduration.DurationParsingException, Overflow),
     )
     def is_duration(instance: object) -> bool:
         if not isinstance(instance, str):

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -2,13 +2,12 @@
 Tests for the parts of jsonschema related to the :kw:`format` keyword.
 """
 
-from unittest import TestCase
-
 from decimal import Overflow
+from unittest import TestCase
 
 from jsonschema import FormatChecker, ValidationError
 from jsonschema.exceptions import FormatError
-from jsonschema.validators import Draft202012Validator, Draft4Validator
+from jsonschema.validators import Draft4Validator, Draft202012Validator
 
 BOOM = ValueError("Boom!")
 BANG = ZeroDivisionError("Bang!")
@@ -102,7 +101,6 @@ class TestFormatChecker(TestCase):
         except ImportError:
             self.skipTest("isoduration not installed")
 
-        from jsonschema.validators import Draft202012Validator
 
         validator = Draft202012Validator(
             {"format": "duration"}, format_checker=FormatChecker(),

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -4,9 +4,11 @@ Tests for the parts of jsonschema related to the :kw:`format` keyword.
 
 from unittest import TestCase
 
+from decimal import Overflow
+
 from jsonschema import FormatChecker, ValidationError
 from jsonschema.exceptions import FormatError
-from jsonschema.validators import Draft4Validator
+from jsonschema.validators import Draft202012Validator, Draft4Validator
 
 BOOM = ValueError("Boom!")
 BANG = ZeroDivisionError("Bang!")
@@ -89,3 +91,22 @@ class TestFormatChecker(TestCase):
             repr(checker),
             "<FormatChecker checkers=['bar', 'baz', 'foo']>",
         )
+
+    def test_duration_with_large_exponent_is_invalid(self):
+        # isoduration.parse_duration can raise decimal.Overflow for
+        # values with very large exponents, which is not a subclass of
+        # DurationParsingException and would otherwise escape the
+        # format checker uncaught.
+        try:
+            import isoduration  # noqa: F401
+        except ImportError:
+            self.skipTest("isoduration not installed")
+
+        from jsonschema.validators import Draft202012Validator
+
+        validator = Draft202012Validator(
+            {"format": "duration"}, format_checker=FormatChecker(),
+        )
+        errors = list(validator.iter_errors("P1E1000000D"))
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0].cause, Overflow)


### PR DESCRIPTION
Fixes #1511

The `is_duration` format checker delegates to `isoduration.parse_duration()`, which can raise `decimal.Overflow` when parsing duration strings with very large exponents (e.g. `P1E1000000D`). This exception is not a subclass of `isoduration.DurationParsingException`, so it was not included in the `raises` parameter and escaped the format checker uncaught — causing the validator to crash instead of reporting the instance as invalid.

This adds `decimal.Overflow` to the `raises` tuple so the exception is caught and the instance is reported as failing the `duration` format, consistent with how other parse errors are handled.

```python
from jsonschema import Draft202012Validator, FormatChecker

v = Draft202012Validator({"format": "duration"}, format_checker=FormatChecker())
# Before: raises decimal.Overflow
# After: returns a FormatError
list(v.iter_errors("P1E1000000D"))
```