### PR TITLE
Fix uniq comparisons across hashability paths

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -217,13 +217,14 @@ def uniq(container):
     brute force when necessary.
     """
     seen_keys = set()
+    supported = []
     unsupported = []
 
     for element in container:
         key = _uniq_key(element)
 
         if key is _UNSUPPORTED:
-            for previous in unsupported:
+            for previous in [*supported, *unsupported]:
                 if equal(previous, element):
                     return False
             unsupported.append(element)
@@ -231,8 +232,11 @@ def uniq(container):
 
         if key in seen_keys:
             return False
+        if any(equal(previous, element) for previous in unsupported):
+            return False
 
         seen_keys.add(key)
+        supported.append(element)
 
     return True
 

--- a/jsonschema/tests/test_utils.py
+++ b/jsonschema/tests/test_utils.py
@@ -223,3 +223,7 @@ class TestUniq(TestCase):
         self.assertTrue(
             uniq([{"k": Unhashable(1)}, {"k": Unhashable(2)}]),
         )
+
+    def test_equal_hashable_and_unhashable_values_are_not_unique(self):
+        self.assertFalse(uniq([{1}, frozenset({1})]))
+        self.assertFalse(uniq([frozenset({1}), {1}]))


### PR DESCRIPTION
`uniq()` could report equal values as unique when one uses the structural-hash path and the other falls back to pairwise comparison (for example, `set` and `frozenset`). Compare fallback values across both paths so the result no longer depends on input order.
