### PR TITLE
Fix multipleOf crashing on Decimal instances and large integers

### DIFF
--- a/jsonschema/_keywords.py
+++ b/jsonschema/_keywords.py
@@ -169,15 +169,17 @@ def multipleOf(validator, dB, instance, schema):
         return
 
     if isinstance(dB, float):
-        quotient = instance / dB
         try:
+            quotient = instance / dB
             failed = int(quotient) != quotient
-        except OverflowError:
-            # When `instance` is large and `dB` is less than one,
-            # quotient can overflow to infinity; and then casting to int
-            # raises an error.
+        except (OverflowError, TypeError):
+            # When `instance` is large and `dB` is less than one, the
+            # quotient can overflow to infinity (or dividing a huge integer
+            # can overflow outright), and then casting to int raises an
+            # OverflowError; and a `Decimal` instance cannot be divided by a
+            # float `dB` at all, which raises a TypeError.
             #
-            # In this case we fall back to Fraction logic, which is
+            # In either case we fall back to Fraction logic, which is
             # exact and cannot overflow.  The performance is also
             # acceptable: we try the fast all-float option first, and
             # we know that fraction(dB) can have at most a few hundred

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -816,6 +816,29 @@ class TestValidationErrorMessages(TestCase):
         )
 
 
+class TestMultipleOf(TestCase):
+    def test_it_does_not_crash_on_decimals_or_large_integers(self):
+        # ``multipleOf`` with a float divisor divides the instance by the
+        # divisor. The division used to sit outside the guard that only
+        # caught OverflowError, so a Decimal instance raised TypeError
+        # (Decimal / float) and a very large integer raised OverflowError at
+        # the division itself, instead of validating.
+        Validator = validators.Draft202012Validator
+
+        # Both of these are valid (10.0 is a multiple of 2.5, and every
+        # integer is a multiple of 0.5) and must not raise.
+        Validator({"multipleOf": 2.5}).validate(Decimal("10.0"))
+        Validator({"multipleOf": 0.5}).validate(10**400)
+
+        # The Fraction fallback still rejects genuine non-multiples.
+        self.assertFalse(
+            Validator({"multipleOf": 3.3}).is_valid(Decimal("10")),
+        )
+        self.assertFalse(
+            Validator({"multipleOf": 0.3}).is_valid(10**400),
+        )
+
+
 class TestValidationErrorDetails(TestCase):
     # TODO: These really need unit tests for each individual keyword, rather
     #       than just these higher level tests.

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -832,7 +832,7 @@ class TestMultipleOf(TestCase):
 
         # The Fraction fallback still rejects genuine non-multiples.
         self.assertFalse(
-            Validator({"multipleOf": 3.3}).is_valid(Decimal("10")),
+            Validator({"multipleOf": 3.3}).is_valid(Decimal(10)),
         )
         self.assertFalse(
             Validator({"multipleOf": 0.3}).is_valid(10**400),


### PR DESCRIPTION
### The bug

`multipleOf` with a float divisor raises an uncaught exception (instead of validating) for two reasonable inputs:

```python
import json
from decimal import Decimal
from jsonschema import Draft202012Validator as V

# (a) a Decimal instance, e.g. from json.loads(text, parse_float=Decimal)
list(V({"multipleOf": 2.5}).iter_errors(Decimal("10.0")))
# TypeError: unsupported operand type(s) for /: 'decimal.Decimal' and 'float'

# (b) a very large integer instance
list(V({"multipleOf": 0.5}).iter_errors(10**400))
# OverflowError: int too large to convert to float
```

Both should validate successfully: `10.0` is a multiple of `2.5`, and every integer is a multiple of `0.5`. `Decimal` is a supported instance type (it is a `numbers.Number`, and there is an existing `test_it_can_validate_with_decimals`), and `Decimal` instances arise naturally from `json.loads(text, parse_float=Decimal)`.

### Root cause

In the `float` branch of `multipleOf` (`jsonschema/_keywords.py`), the division was placed *outside* the `try`, and the `except` only caught `OverflowError`:

```python
if isinstance(dB, float):
    quotient = instance / dB          # <- outside the guard
    try:
        failed = int(quotient) != quotient
    except OverflowError:
        ...
        failed = (Fraction(instance) / Fraction(dB)).denominator != 1
```

So the division could raise uncaught: `TypeError` for `Decimal / float`, and `OverflowError` when a huge integer is divided by a float (the division itself overflows, before the `int()` cast the guard was written for).

### Fix

Move the division inside the `try` and also catch `TypeError`, so both cases fall back to the exact, overflow-proof `Fraction` computation that was already there:

```python
if isinstance(dB, float):
    try:
        quotient = instance / dB
        failed = int(quotient) != quotient
    except (OverflowError, TypeError):
        ...
        failed = (Fraction(instance) / Fraction(dB)).denominator != 1
```

The `else` (`instance % dB`) path and the fast float path are unchanged.

### Tests

Added `TestMultipleOf.test_it_does_not_crash_on_decimals_or_large_integers` to `jsonschema/tests/test_validators.py`. It fails before the change (`TypeError` at the division) and passes after; it also checks the `Fraction` fallback still rejects genuine non-multiples (`Decimal("10")` vs `3.3`, `10**400` vs `0.3`). The full `test_validators.py` (304) and the official Test Suite `multipleOf` cases (55) pass. Happy to add a CHANGELOG entry if you'd like.