### PR TITLE
deps: use optional dependency `rfc3987-syntax2` instead of `rfc3987-syntax`

### DIFF
--- a/docs/validate.rst
+++ b/docs/validate.rst
@@ -231,8 +231,8 @@ Checker                    Notes
 ``idn-hostname``           requires idna_
 ``ipv4``
 ``ipv6``                   OS must have `socket.inet_pton` function
-``iri``                    requires rfc3987_ or rfc3987-syntax_
-``iri-reference``          requires rfc3987_ or rfc3987-syntax_
+``iri``                    requires rfc3987_ or rfc3987-syntax2_
+``iri-reference``          requires rfc3987_ or rfc3987-syntax2_
 ``json-pointer``           requires jsonpointer_
 ``regex``
 ``relative-json-pointer``  requires jsonpointer_
@@ -251,7 +251,7 @@ Checker                    Notes
 .. _rfc3339-validator: https://pypi.org/project/rfc3339-validator/
 .. _rfc3986-validator: https://pypi.org/project/rfc3986-validator/
 .. _rfc3987: https://pypi.org/pypi/rfc3987/
-.. _rfc3987-syntax: https://pypi.org/pypi/rfc3987-syntax/
+.. _rfc3987-syntax2: https://pypi.org/pypi/rfc3987-syntax2/
 .. _uri-template: https://pypi.org/pypi/uri-template/
 .. _webcolors: https://pypi.org/pypi/webcolors/
 

--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -326,7 +326,7 @@ except ImportError:
             return validate_rfc3986(instance, rule="URI_reference")
 
     with suppress(ImportError):
-        from rfc3987_syntax import is_valid_syntax as _rfc3987_is_valid_syntax
+        from rfc3987_syntax2 import is_valid_syntax as _rfc3987_is_valid_syntax
 
         @_checks_drafts(
             draft7="iri",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ format-nongpl = [
   "jsonpointer>1.13",
   "rfc3339-validator",
   "rfc3986-validator>0.1.0",
-  "rfc3987-syntax2>=1.2.0",
+  "rfc3987-syntax2>=1.3.0,<2",
   "uri_template",
   "webcolors>=24.6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ format-nongpl = [
   "jsonpointer>1.13",
   "rfc3339-validator",
   "rfc3986-validator>0.1.0",
-  "rfc3987-syntax>=1.1.0",
+  "rfc3987-syntax2>=1.2.0",
   "uri_template",
   "webcolors>=24.6.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -173,7 +173,7 @@ format-nongpl = [
     { name = "jsonpointer" },
     { name = "rfc3339-validator" },
     { name = "rfc3986-validator" },
-    { name = "rfc3987-syntax" },
+    { name = "rfc3987-syntax2" },
     { name = "uri-template" },
     { name = "webcolors" },
 ]
@@ -201,7 +201,7 @@ requires-dist = [
     { name = "rfc3339-validator", marker = "extra == 'format-nongpl'" },
     { name = "rfc3986-validator", marker = "extra == 'format-nongpl'", specifier = ">0.1.0" },
     { name = "rfc3987", marker = "extra == 'format'" },
-    { name = "rfc3987-syntax", marker = "extra == 'format-nongpl'", specifier = ">=1.1.0" },
+    { name = "rfc3987-syntax2", marker = "extra == 'format-nongpl'", specifier = ">=1.2.0" },
     { name = "rpds-py", specifier = ">=0.25.0" },
     { name = "uri-template", marker = "extra == 'format'" },
     { name = "uri-template", marker = "extra == 'format-nongpl'" },
@@ -331,15 +331,15 @@ wheels = [
 ]
 
 [[package]]
-name = "rfc3987-syntax"
-version = "1.1.0"
+name = "rfc3987-syntax2"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lark" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/51/376d3bfb8f10961f4813894064e423e64fd5f9a8ddf40d8c7673e84cdfb4/rfc3987_syntax2-1.2.0.tar.gz", hash = "sha256:033254a1ae0e8790a1ec81c4096d7ae6b4dafe1e3af9220cc9fb27fb62e6905a", size = 14442, upload-time = "2026-07-16T12:27:15.589Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
+    { url = "https://files.pythonhosted.org/packages/49/db/f7098dc48ab61ace9d3d113dc2f03f591fb9e8e049182bce5a1311bbff9f/rfc3987_syntax2-1.2.0-py3-none-any.whl", hash = "sha256:5a9bcec814bcb8d718aae723d02048d8750eafeeb0a3df76c2519aba54d2c7b2", size = 7960, upload-time = "2026-07-16T12:27:14.426Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ requires-dist = [
     { name = "rfc3339-validator", marker = "extra == 'format-nongpl'" },
     { name = "rfc3986-validator", marker = "extra == 'format-nongpl'", specifier = ">0.1.0" },
     { name = "rfc3987", marker = "extra == 'format'" },
-    { name = "rfc3987-syntax2", marker = "extra == 'format-nongpl'", specifier = ">=1.2.0" },
+    { name = "rfc3987-syntax2", marker = "extra == 'format-nongpl'", specifier = ">=1.3.0,<2" },
     { name = "rpds-py", specifier = ">=0.25.0" },
     { name = "uri-template", marker = "extra == 'format'" },
     { name = "uri-template", marker = "extra == 'format-nongpl'" },
@@ -332,14 +332,14 @@ wheels = [
 
 [[package]]
 name = "rfc3987-syntax2"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lark" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/51/376d3bfb8f10961f4813894064e423e64fd5f9a8ddf40d8c7673e84cdfb4/rfc3987_syntax2-1.2.0.tar.gz", hash = "sha256:033254a1ae0e8790a1ec81c4096d7ae6b4dafe1e3af9220cc9fb27fb62e6905a", size = 14442, upload-time = "2026-07-16T12:27:15.589Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/a1/2030da67540b06392d41192902ad540d0c4bb5c6941b48d9b0bc94df74cf/rfc3987_syntax2-1.3.0.tar.gz", hash = "sha256:5df078da42c192e1251ed9c0887ee92f8062375afcf03bf65b5e2d77eaa00f36", size = 25134, upload-time = "2026-07-21T17:04:19.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/db/f7098dc48ab61ace9d3d113dc2f03f591fb9e8e049182bce5a1311bbff9f/rfc3987_syntax2-1.2.0-py3-none-any.whl", hash = "sha256:5a9bcec814bcb8d718aae723d02048d8750eafeeb0a3df76c2519aba54d2c7b2", size = 7960, upload-time = "2026-07-16T12:27:14.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/b420e0ca053c2c14ad7f5eb0af683dee5a26da575e108601e230170bf3fe/rfc3987_syntax2-1.3.0-py3-none-any.whl", hash = "sha256:1ae7c68fc09d20739b6cb6b08e04b40f8c83305fd5f24ba1e5e1e24855d42210", size = 11363, upload-time = "2026-07-21T17:04:18.298Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
in #1388 a non-gpl library for validating IRI was introduced.

Unfortunately, the library `rfc3987-syntax` (<https://pypi.org/project/rfc3987-syntax/>) is no longer maintained.
Therefore, a maintained fork `rfc3987-syntax2` (<https://pypi.org/project/rfc3987-syntax2/>) exists, which is used here. 

`rfc3987-syntax2` v1.3.0 has various improvements over the old `rfc3987-syntax` v1.1.0
- lazy-loading - improving import times tremendously
    - simple bench  
      ```shellSession
      $ # new lib
      $ time python -c "from rfc3987_syntax2 import is_valid_syntax as _rfc3987_is_valid_syntax"
      
      ________________________________________________________
      Executed in  149.03 millis    fish           external
         usr time  133.83 millis    0.00 micros  133.83 millis
         sys time   13.60 millis  708.00 micros   12.89 millis
    
      $ # old lib 
      $ time python -c "from rfc3987_syntax import is_valid_syntax as _rfc3987_is_valid_syntax"
      
      ________________________________________________________
      Executed in    2.20 secs    fish           external
         usr time    2.16 secs  782.00 micros    2.16 secs
         sys time    0.03 secs  115.00 micros    0.03 secs
      ```
  - test compare in CI pipeline
    - new lib on PR: **10.006s** - https://github.com/python-jsonschema/jsonschema/actions/runs/29859393697/job/88731960392?pr=1521#step:8:8839 
    - old lib on main: **27.485s** - https://github.com/python-jsonschema/jsonschema/actions/runs/29805998926/job/88556570183#step:8:8839

- is RFC 3987 syntax complete (old lib had blind-spots)
- various bug fixes
  - https://github.com/jkowalleck/rfc3987-syntax2/releases#release-v1.3.0
  - https://github.com/jkowalleck/rfc3987-syntax2/releases#release-v1.2.0 
  - https://github.com/jkowalleck/rfc3987-syntax2/releases#release-v1.1.1
- proper typing and API docs