### PR TITLE
Fix find_additional_properties ignoring an empty patternProperties key

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -82,12 +82,13 @@ def find_additional_properties(instance, schema):
     Assumes ``instance`` is dict-like already.
     """
     properties = schema.get("properties", {})
-    patterns = "|".join(schema.get("patternProperties", {}))
+    patterns = schema.get("patternProperties", {})
     for property in instance:
-        if property not in properties:
-            if patterns and re.search(patterns, property):
-                continue
-            yield property
+        if property in properties:
+            continue
+        if any(re.search(pattern, property) for pattern in patterns):
+            continue
+        yield property
 
 
 def extras_msg(extras):

--- a/jsonschema/tests/test_utils.py
+++ b/jsonschema/tests/test_utils.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from math import nan
 from unittest import TestCase
 
-from jsonschema._utils import equal, uniq
+from jsonschema._utils import equal, find_additional_properties, uniq
 
 
 class Unhashable:
@@ -222,4 +222,22 @@ class TestUniq(TestCase):
         )
         self.assertTrue(
             uniq([{"k": Unhashable(1)}, {"k": Unhashable(2)}]),
+        )
+
+
+class TestFindAdditionalProperties(TestCase):
+    def test_empty_pattern_matches_all_properties(self):
+        # An empty-string pattern is a valid regex that matches every property,
+        # so patternProperties covers everything and nothing is additional.
+        schema = {"patternProperties": {"": {"type": "integer"}}}
+        instance = {"foo": 1, "bar": 2}
+        self.assertEqual(
+            list(find_additional_properties(instance, schema)), [],
+        )
+
+    def test_no_pattern_properties_leaves_all_additional(self):
+        schema = {"properties": {"foo": {}}}
+        instance = {"foo": 1, "bar": 2}
+        self.assertEqual(
+            list(find_additional_properties(instance, schema)), ["bar"],
         )


### PR DESCRIPTION
`find_additional_properties` in `jsonschema/_utils.py` collapses every `patternProperties` key into one regex with `"|".join(...)` and then guards it with `if patterns`:

```python
patterns = "|".join(schema.get("patternProperties", {}))
for property in instance:
    if property not in properties:
        if patterns and re.search(patterns, property):
            continue
        yield property
```

`"|".join` maps both an empty `patternProperties` and `{"": ...}` to the same empty string, and `if patterns` then treats that empty (match-everything) pattern as absent. So an empty-string pattern key, which is a valid regex that matches every property, is silently dropped: its properties are reported as additional and validated against `additionalProperties` instead of the pattern subschema.

```python
from jsonschema import Draft202012Validator as D

# "" matches every property, so patternProperties owns "x"; nothing is additional.
list(D({"additionalProperties": False,
        "patternProperties": {"": {"type": "integer"}}}).iter_errors({"x": 1}))
# before: ["'x' does not match any of the regexes: ''"]   (should be valid)

# The wrong subschema is applied, not just a spurious message:
list(D({"patternProperties": {"": {"type": "string"}},
        "additionalProperties": {"type": "integer"}}).iter_errors({"x": "hi"}))
# before: ["'hi' is not of type 'integer'"]   (should be valid: "x" matches "" -> string subschema)
```

The sibling helper `find_evaluated_property_keys_by_schema` (used for `unevaluatedProperties`) already iterates the patterns individually with `re.search`, so the two helpers disagree on the same schema. This change makes `find_additional_properties` do the same: iterate the `patternProperties` dict and skip a property if any pattern matches, which distinguishes "no patterns" (nothing to match) from an empty-string pattern (matches everything).

Added `TestFindAdditionalProperties` in `jsonschema/tests/test_utils.py` (fails before, passes after). The full JSON-Schema-Test-Suite still passes with no regressions.
