### PR TITLE
Fix ErrorTree.__getitem__ mutating the tree as a side effect of reading

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -3,7 +3,7 @@ Validation errors, and some surrounding helpers.
 """
 from __future__ import annotations
 
-from collections import defaultdict, deque
+from collections import deque
 from pprint import pformat
 from textwrap import dedent, indent
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -321,12 +321,18 @@ class ErrorTree:
 
     def __init__(self, errors: Iterable[ValidationError] = ()):
         self.errors: MutableMapping[str, ValidationError] = {}
-        self._contents: Mapping[str, ErrorTree] = defaultdict(self.__class__)
+        self._contents: MutableMapping[str, ErrorTree] = {}
 
         for error in errors:
             container = self
             for element in error.path:
-                container = container[element]
+                # Populate (and persist) intermediate nodes directly,
+                # bypassing __getitem__ -- which, for public callers,
+                # must *not* have the side effect of adding an index to
+                # the tree merely by reading it. See GH #1328.
+                container = container._contents.setdefault(
+                    element, self.__class__(),
+                )
             container.errors[error.validator] = error
 
             container._instance = error.instance
@@ -345,10 +351,16 @@ class ErrorTree:
         to and is not known by this tree, whatever error would be raised
         by ``instance.__getitem__`` will be propagated (usually this is
         some subclass of `LookupError`.
+
+        Note that unlike a normal mapping, accessing an index which has
+        no known errors does not add that index to the tree -- it
+        simply returns a new, empty `ErrorTree`. Use `in` (see
+        `ErrorTree.__contains__`) or `iter` (see `ErrorTree.__iter__`)
+        to check which indices are actually known to have errors.
         """
         if self._instance is not _unset and index not in self:
             self._instance[index]
-        return self._contents[index]
+        return self._contents.get(index, self.__class__())
 
     def __setitem__(self, index: str | int, value: ErrorTree):
         """

--- a/jsonschema/tests/test_exceptions.py
+++ b/jsonschema/tests/test_exceptions.py
@@ -404,6 +404,26 @@ class TestErrorTree(TestCase):
         tree = exceptions.ErrorTree(errors)
         self.assertNotIn("foo", tree)
 
+    def test_accessing_an_index_with_no_error_does_not_add_it(self):
+        """
+        Regression test for
+        https://github.com/python-jsonschema/jsonschema/issues/1328
+
+        Merely reading ``tree[index]`` for an index with no error must
+        not have the side effect of making that index appear to have
+        one on subsequent ``__contains__`` / ``__iter__`` calls.
+        """
+        errors = [exceptions.ValidationError("a message", path=["bar"])]
+        tree = exceptions.ErrorTree(errors)
+
+        self.assertNotIn("foo", tree)
+        self.assertEqual(list(tree), ["bar"])
+
+        tree["foo"]  # merely accessing it should not add it
+
+        self.assertNotIn("foo", tree)
+        self.assertEqual(list(tree), ["bar"])
+
     def test_keywords_that_failed_appear_in_errors_dict(self):
         error = exceptions.ValidationError("a message", validator="foo")
         tree = exceptions.ErrorTree([error])


### PR DESCRIPTION
Fixes #1328.

`ErrorTree._contents` was a `defaultdict(self.__class__)`, and `__getitem__` returned `self._contents[index]` directly. On a plain `defaultdict`, subscripting a missing key auto-vivifies and *persists* an empty value for that key as a side effect of the read. Since `__contains__` and `__iter__` both check/iterate `self._contents`'s keys, merely reading `tree[index]` for an index with no actual error would permanently (and incorrectly) make that index appear to have one on every subsequent containment check or iteration -- contradicting the documented behavior and the class's own docstrings, as shown in the issue.

`ErrorTree.__init__` itself relies on this auto-vivify behavior to walk and build nested trees while consuming each error's path, so the fix can't simply drop the behavior everywhere: construction needs child nodes to persist, but public reads must not create phantom entries.

**Fix**: use a plain `dict` for `_contents`. In `__init__`, populate (and persist) intermediate nodes directly via `container._contents.setdefault(...)`, bypassing `__getitem__` entirely for construction. The public `__getitem__` now returns `self._contents.get(index, self.__class__())` -- a fresh, empty, non-persisted `ErrorTree` when there's no existing entry, leaving `_contents` (and therefore `__contains__`/`__iter__`) untouched by reads.

**Testing**: added a regression test that reproduces the exact scenario from the issue: reading `tree[index]` for an index with no error, then asserting `__contains__`/`__iter__` are unaffected. I confirmed the test fails with the original `defaultdict`-based implementation and passes with the fix.

Ran the full existing `test_exceptions.py` suite (59 tests, all pass) and the entire project test suite with a fixed random seed to rule out unrelated test-order flakiness from `pytest-randomly` (I initially saw 2 unrelated failures with random ordering that also occur on a clean checkout of `main` with the same seed -- 7942 passed, 571 skipped, both with and without this fix, aside from the one new test).