### PR TITLE
Fix duration format overflow handling

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from contextlib import suppress
 from datetime import date, datetime
 from uuid import UUID
+import decimal
 import ipaddress
 import re
 import string
@@ -518,7 +519,10 @@ with suppress(ImportError):
     @_checks_drafts(
         draft201909="duration",
         draft202012="duration",
-        raises=isoduration.DurationParsingException,
+        raises=(
+            isoduration.DurationParsingException,
+            decimal.DecimalException,
+        ),
     )
     def is_duration(instance: object) -> bool:
         if not isinstance(instance, str):

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -80,6 +80,14 @@ class TestFormatChecker(TestCase):
         with self.assertRaises(FormatError):
             checker.check(instance="not-an-ipv4", format="ipv4")
 
+    def test_duration_overflow_is_invalid(self):
+        checker = FormatChecker()
+        if "duration" not in checker.checkers:
+            self.skipTest("isoduration is not installed")
+
+        with self.assertRaises(FormatError):
+            checker.check(instance="P1E1000000D", format="duration")
+
     def test_repr(self):
         checker = FormatChecker(formats=())
         checker.checks("foo")(lambda thing: True)  # pragma: no cover


### PR DESCRIPTION
Fixes #1511.

## Summary
- catch decimal parsing exceptions raised by isoduration while checking the duration format
- add a regression test for large exponent duration strings so they become format validation errors instead of uncaught decimal.Overflow exceptions

## Tests
- .venv/bin/python -m unittest jsonschema.tests.test_format.TestFormatChecker.test_duration_overflow_is_invalid
- .venv/bin/python -m unittest jsonschema.tests.test_format
- .venv/bin/virtue jsonschema/tests/test_format.py
- .venv/bin/python -m ruff check jsonschema/_format.py jsonschema/tests/test_format.py