### PR TITLE
Report oversized regex repeat count as invalid instead of crashing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+v4.27.0
+=======
+
+* Report a string as an invalid ``regex`` format rather than crashing when it contains a syntactically valid but oversized repetition count (which makes ``re.compile`` raise ``OverflowError`` instead of ``re.error``).
+
 v4.26.0
 =======
 

--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -413,7 +413,7 @@ with suppress(ImportError):
         return is_datetime("1970-01-01T" + instance)
 
 
-@_checks_drafts(name="regex", raises=re.error)
+@_checks_drafts(name="regex", raises=(re.error, OverflowError))
 def is_regex(instance: object) -> bool:
     if not isinstance(instance, str):
         return True

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -80,6 +80,15 @@ class TestFormatChecker(TestCase):
         with self.assertRaises(FormatError):
             checker.check(instance="not-an-ipv4", format="ipv4")
 
+    def test_regex_format_rejects_overflowing_repeat_count(self):
+        # A syntactically valid but oversized repetition count makes
+        # re.compile raise OverflowError, which is not an re.error, so it
+        # must be declared alongside it or it escapes uncaught instead of
+        # being reported as an invalid regex.
+        checker = FormatChecker()
+        with self.assertRaises(FormatError):
+            checker.check(instance="a{99999999999999}", format="regex")
+
     def test_repr(self):
         checker = FormatChecker(formats=())
         checker.checks("foo")(lambda thing: True)  # pragma: no cover


### PR DESCRIPTION
The `regex` format checker is declared with `raises=re.error`:

```python
@_checks_drafts(name="regex", raises=re.error)
def is_regex(instance: object) -> bool:
    if not isinstance(instance, str):
        return True
    return bool(re.compile(instance))
```

`FormatChecker.check` only converts the declared exception(s) into a `FormatError`. But `re.compile` raises `OverflowError` (which is **not** an `re.error` subclass) when a repetition count is too large, e.g. `re.compile("a{99999999999999}")`. That `OverflowError` escapes uncaught, so a `regex`-format check on such a string crashes instead of reporting it as an invalid regex, unlike every other malformed pattern (which raises `re.error` and is caught).

```python
>>> from jsonschema import FormatChecker
>>> fc = FormatChecker()
>>> fc.conforms("[unterminated", "regex")   # re.error -> caught
False
>>> fc.conforms("a{99999999999999}", "regex")   # OverflowError -> escapes
Traceback (most recent call last):
  ...
OverflowError: the repetition number is too large
```

The same escape happens through `iter_errors`/`validate` when `format` checking is enabled.

## Fix

Declare the checker with `raises=(re.error, OverflowError)` so the oversized-repeat case is reported as an invalid regex like the rest. This matches sibling checkers that already pass exception tuples (e.g. `raises=(idna.IDNAError, UnicodeError)`). No behavior change for valid patterns or for `re.error` cases.

## Tests

Added `TestFormatChecker.test_regex_format_rejects_overflowing_repeat_count`, mirroring the existing `test_format_checkers_come_with_defaults` (uses `checker.check(...)` + `assertRaises(FormatError)`).

- Before: the new test errors with an uncaught `OverflowError`.
- After: it passes; `conforms("a{99999999999999}", "regex")` returns `False`, while `conforms("[unterminated", "regex")` stays `False` and `conforms("valid.*regex", "regex")` stays `True`.
- `python -m pytest jsonschema/tests/test_format.py` -> 9 passed.

Added a CHANGELOG entry.
