### PR TITLE
Pin optional dependencies to python>=3.10,<3.15 buildable versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,17 +47,17 @@ dependencies = [
 [project.optional-dependencies]
 format = [
   "fqdn",
-  "idna",
+  "idna>=0.3",
   "isoduration",
   "jsonpointer>1.13",
   "rfc3339-validator",
-  "rfc3987",
+  "rfc3987>=1.3",
   "uri_template",
   "webcolors>=1.11",
 ]
 format-nongpl = [
   "fqdn",
-  "idna",
+  "idna>=0.3",
   "isoduration",
   "jsonpointer>1.13",
   "rfc3339-validator",


### PR DESCRIPTION
`idna<0.3` and `rfc3987<1.3` do not build on python versions 3.10 through 3.14. This PR changes pyproject.toml to specifically require versions compatible with the stated `requires-python = ">=3.10"`.

## Tests

I tested builds with `uv sync --resolution=lowest-direct` and ran `nox` with the updated lockfile, passing all tests