### PR TITLE
Report huge durations as invalid instead of raising decimal.Overflow

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from contextlib import suppress
 from datetime import date, datetime
 from uuid import UUID
+import decimal
 import ipaddress
 import re
 import string
@@ -518,7 +519,7 @@ with suppress(ImportError):
     @_checks_drafts(
         draft201909="duration",
         draft202012="duration",
-        raises=isoduration.DurationParsingException,
+        raises=(isoduration.DurationParsingException, decimal.Overflow),
     )
     def is_duration(instance: object) -> bool:
         if not isinstance(instance, str):

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -2,11 +2,16 @@
 Tests for the parts of jsonschema related to the :kw:`format` keyword.
 """
 
-from unittest import TestCase
+from unittest import TestCase, skipUnless
 
 from jsonschema import FormatChecker, ValidationError
 from jsonschema.exceptions import FormatError
 from jsonschema.validators import Draft4Validator
+
+try:
+    import isoduration
+except ImportError:
+    isoduration = None
 
 BOOM = ValueError("Boom!")
 BANG = ZeroDivisionError("Bang!")
@@ -79,6 +84,24 @@ class TestFormatChecker(TestCase):
         checker = FormatChecker()
         with self.assertRaises(FormatError):
             checker.check(instance="not-an-ipv4", format="ipv4")
+
+    @skipUnless(isoduration is not None, "isoduration not installed")
+    def test_duration_with_a_huge_exponent_is_invalid_not_an_error(self):
+        # A duration amount whose magnitude exceeds the decimal context's
+        # ``Emax`` makes isoduration's ``Decimal(...)`` raise
+        # ``decimal.Overflow`` rather than ``DurationParsingException``.  Such
+        # a string is not a valid RFC 3339 Appendix A duration and should be
+        # reported as invalid, not propagate an uncaught exception.
+        checker = FormatChecker()
+        with self.assertRaises(FormatError):
+            checker.check(instance="P1E1000000D", format="duration")
+
+    @skipUnless(isoduration is not None, "isoduration not installed")
+    def test_duration_with_a_huge_digit_run_is_invalid_not_an_error(self):
+        checker = FormatChecker()
+        instance = "P" + "1" * 1000001 + "D"
+        with self.assertRaises(FormatError):
+            checker.check(instance=instance, format="duration")
 
     def test_repr(self):
         checker = FormatChecker(formats=())


### PR DESCRIPTION
Fixes #1511.

The `duration` format checker delegates to `isoduration.parse_duration`, which parses each numeric component with `Decimal(...)`. When a component's magnitude exceeds the decimal context's `Emax` (e.g. `P1E1000000D`, or a digit run longer than `Emax`), `Decimal` raises `decimal.Overflow`. Because the checker was registered only with `raises=isoduration.DurationParsingException`, and `decimal.Overflow` is an `ArithmeticError` rather than a `DurationParsingException`, the exception propagated uncaught out of format validation instead of the instance being reported invalid.

Such strings are not valid RFC 3339 Appendix A durations (the grammar is `1*DIGIT`, no exponent), so they should be reported invalid. This broadens the checker's caught exceptions to include `decimal.Overflow`.

Added regression tests for both the large-exponent and long-digit-run cases, guarded with `skipUnless` so they skip when the optional `isoduration` dependency isn't installed.
