### PR TITLE
Support Draft 2020-12 relative JSON Pointer index manipulation

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -475,7 +475,6 @@ with suppress(ImportError):
     @_checks_drafts(
         draft7="relative-json-pointer",
         draft201909="relative-json-pointer",
-        draft202012="relative-json-pointer",
         raises=jsonpointer.JsonPointerException,
     )
     def is_relative_json_pointer(instance: object) -> bool:
@@ -494,6 +493,29 @@ with suppress(ImportError):
             return False
         if len(prefix) > 1 and prefix[0] == "0":
             return False
+        return (rest == "#") or bool(jsonpointer.JsonPointer(rest))
+
+    @_checks_drafts(
+        draft202012="relative-json-pointer",
+        raises=jsonpointer.JsonPointerException,
+    )
+    def is_relative_json_pointer_202012(instance: object) -> bool:
+        # Definition taken from:
+        # https://json-schema.org/draft/2020-12/relative-json-pointer
+        if not isinstance(instance, str):
+            return True
+        if not instance:
+            return False
+
+        prefix = re.match(
+            r"(?:0|[1-9][0-9]*)(?:[+-](?:0|[1-9][0-9]*))?",
+            instance,
+            re.ASCII,
+        )
+        if prefix is None:
+            return False
+
+        rest = instance[prefix.end():]
         return (rest == "#") or bool(jsonpointer.JsonPointer(rest))
 
 

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -6,7 +6,12 @@ from unittest import TestCase
 
 from jsonschema import FormatChecker, ValidationError
 from jsonschema.exceptions import FormatError
-from jsonschema.validators import Draft4Validator
+from jsonschema.validators import (
+    Draft4Validator,
+    Draft7Validator,
+    Draft201909Validator,
+    Draft202012Validator,
+)
 
 BOOM = ValueError("Boom!")
 BANG = ZeroDivisionError("Bang!")
@@ -89,3 +94,40 @@ class TestFormatChecker(TestCase):
             repr(checker),
             "<FormatChecker checkers=['bar', 'baz', 'foo']>",
         )
+
+
+class TestRelativeJSONPointer(TestCase):
+    def _checker(self):
+        checker = Draft202012Validator.FORMAT_CHECKER
+        if "relative-json-pointer" not in checker.checkers:
+            self.skipTest("requires the format extra")
+        return checker
+
+    def test_draft202012_allows_index_manipulation(self):
+        checker = self._checker()
+
+        for instance in ("0+1", "0+1/foo", "1-2/bar", "0-0", "0-1#"):
+            with self.subTest(instance=instance):
+                checker.check(instance, "relative-json-pointer")
+
+    def test_older_drafts_still_reject_index_manipulation(self):
+        self._checker()
+        for validator in (Draft7Validator, Draft201909Validator):
+            with (
+                self.subTest(validator=validator.__name__),
+                self.assertRaises(FormatError),
+            ):
+                validator.FORMAT_CHECKER.check(
+                    "0+1/foo",
+                    "relative-json-pointer",
+                )
+
+    def test_draft202012_rejects_malformed_index_manipulation(self):
+        checker = self._checker()
+
+        for instance in ("0+", "0-01", "0++1", "0+1not-a-pointer"):
+            with (
+                self.subTest(instance=instance),
+                self.assertRaises(FormatError),
+            ):
+                checker.check(instance, "relative-json-pointer")


### PR DESCRIPTION
Fixes #1533.

## Summary

- Add Draft 2020-12 support for Relative JSON Pointer index manipulation.
- Keep the Draft 7 and Draft 2019-09 checker behavior unchanged.

## Root cause

The same checker was registered for Draft 7, Draft 2019-09, and Draft 2020-12, but it implements the older `draft-handrews-relative-json-pointer-01` syntax. Draft 2020-12 references `draft-bhutton-relative-json-pointer-00`, which adds an optional `+N` or `-N` index manipulation after the initial non-negative integer.

The old checker passes the signed suffix to `jsonpointer.JsonPointer`, so valid values such as `0+1/foo` are rejected because the remainder does not begin with `/`.

## Fix

Register a Draft 2020-12-specific checker that parses the initial integer and optional signed offset before validating the remaining JSON Pointer. Retain the existing function for Draft 7 and Draft 2019-09.

## Tests

- Positive regression covers `0+1`, `0+1/foo`, `1-2/bar`, `0-0`, and `0-1#`.
- Negative controls prove older drafts still reject index manipulation.
- Adversarial controls reject malformed offsets and remainders.
- The full `jsonschema` test suite and targeted ruff checks pass.

## Checklist

- [x] The change includes positive and nearby negative tests.
- [x] Targeted and broader tests pass.
- [x] The change is limited to the format checker and its tests.
- [x] Documentation and changelog changes are not required for this focused correction.
