### PR TITLE
Report deeply nested regex as invalid instead of raising RecursionError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+v4.27.0
+=======
+
+* Report a string as an invalid ``regex`` format rather than crashing when it contains deeply nested groups that make ``re.compile`` raise ``RecursionError`` instead of ``re.error``.
+
 v4.26.0
 =======
 

--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -413,7 +413,7 @@ with suppress(ImportError):
         return is_datetime("1970-01-01T" + instance)
 
 
-@_checks_drafts(name="regex", raises=re.error)
+@_checks_drafts(name="regex", raises=(re.error, RecursionError))
 def is_regex(instance: object) -> bool:
     if not isinstance(instance, str):
         return True

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -80,6 +80,14 @@ class TestFormatChecker(TestCase):
         with self.assertRaises(FormatError):
             checker.check(instance="not-an-ipv4", format="ipv4")
 
+    def test_regex_format_rejects_deeply_nested_pattern(self):
+        # A deeply nested pattern makes re.compile raise RecursionError,
+        # which is not an re.error, so it must be declared alongside it
+        # or it escapes uncaught instead of being reported as invalid.
+        checker = FormatChecker()
+        with self.assertRaises(FormatError):
+            checker.check(instance="(" * 500, format="regex")
+
     def test_repr(self):
         checker = FormatChecker(formats=())
         checker.checks("foo")(lambda thing: True)  # pragma: no cover


### PR DESCRIPTION
Fixes #1538.

## Summary

The `regex` format checker crashes with `RecursionError` instead of reporting the instance as invalid when the pattern contains deeply nested groups.

## Reproduction

`python
from jsonschema import Draft202012Validator, FormatChecker

v = Draft202012Validator({"format": "regex"}, format_checker=FormatChecker())
list(v.iter_errors("(" * 500))
# RecursionError: maximum recursion depth exceeded
`

## Root cause

`re.compile` raises `RecursionError` when the regex pattern nesting exceeds the C stack limit. `RecursionError` is not a subclass of `re.error`, so `FormatChecker.check` does not catch it and the exception propagates uncaught.

This is the same class of issue as the `OverflowError` case in #1526, but a distinct exception type (`RecursionError` inherits from `RuntimeError`, not `ArithmeticError`).

## Fix

Add `RecursionError` alongside `re.error` in the `raises` declaration for `is_regex`, so `FormatChecker.check` converts it to a `FormatError` and the instance is reported as invalid.

## Compatibility

No backward-incompatible changes. Previously crashing inputs now produce a validation error.

## Validation

- New test `test_regex_format_rejects_deeply_nested_pattern` fails before the fix, passes after.
- Full test suite: **8281 passed**, 232 skipped, 0 failures.
- `ruff check` clean on touched files.