### PR TITLE
Catch RecursionError in the regex format checker

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -413,7 +413,7 @@ with suppress(ImportError):
         return is_datetime("1970-01-01T" + instance)
 
 
-@_checks_drafts(name="regex", raises=re.error)
+@_checks_drafts(name="regex", raises=(re.error, RecursionError))
 def is_regex(instance: object) -> bool:
     if not isinstance(instance, str):
         return True

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -80,6 +80,11 @@ class TestFormatChecker(TestCase):
         with self.assertRaises(FormatError):
             checker.check(instance="not-an-ipv4", format="ipv4")
 
+    def test_regex_recursion_error_is_caught(self):
+        checker = FormatChecker()
+        with self.assertRaises(FormatError):
+            checker.check(instance="(" * 500, format="regex")
+
     def test_repr(self):
         checker = FormatChecker(formats=())
         checker.checks("foo")(lambda thing: True)  # pragma: no cover


### PR DESCRIPTION
Fixes #1538

`re.compile` raises `RecursionError` rather than `re.error` when a pattern nests deeply enough to hit the C stack limit, so the checker's `raises=re.error` didn't cover it and the exception escaped the validator instead of being reported as an invalid instance.

Added `RecursionError` to the tuple, plus a test with `"(" * 500`. Same shape as the `OverflowError` case in #1526, just a different exception type.

Full test suite passes locally.