### PR TITLE
Report overflowing durations as invalid instead of crashing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ v4.26.0
 =======
 
 * Decrease import time by delaying importing of ``urllib.request`` (#1416).
+* Report durations whose amounts overflow ``Decimal`` (e.g. ``P1E1000000D``) as invalid instead of raising an uncaught ``decimal.Overflow`` from the ``duration`` format checker (#1511).
 
 v4.25.1
 =======

--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -518,7 +518,7 @@ with suppress(ImportError):
     @_checks_drafts(
         draft201909="duration",
         draft202012="duration",
-        raises=isoduration.DurationParsingException,
+        raises=(isoduration.DurationParsingException, ArithmeticError),
     )
     def is_duration(instance: object) -> bool:
         if not isinstance(instance, str):

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -2,7 +2,8 @@
 Tests for the parts of jsonschema related to the :kw:`format` keyword.
 """
 
-from unittest import TestCase
+from importlib.util import find_spec
+from unittest import TestCase, skipIf
 
 from jsonschema import FormatChecker, ValidationError
 from jsonschema.exceptions import FormatError
@@ -79,6 +80,23 @@ class TestFormatChecker(TestCase):
         checker = FormatChecker()
         with self.assertRaises(FormatError):
             checker.check(instance="not-an-ipv4", format="ipv4")
+
+    @skipIf(
+        find_spec("isoduration") is None,
+        "The isoduration dependency is not installed",
+    )
+    def test_it_rejects_durations_that_overflow_decimal(self):
+        # Decimal parsing in isoduration raises decimal.Overflow (an
+        # ArithmeticError, not a DurationParsingException) for amounts
+        # past the context's Emax, e.g. an exponent of 1E1000000 or a
+        # plain digit run longer than 999999. Those must be reported as
+        # invalid durations rather than escaping the checker.
+        checker = FormatChecker()
+        for instance in ("P1E1000000D", "P" + "9" * 1000000 + "D"):
+            with self.assertRaises(FormatError):
+                checker.check(instance=instance, format="duration")
+        # A well-formed duration is still accepted.
+        self.assertTrue(checker.conforms("P1Y2M3DT4H5M6S", "duration"))
 
     def test_repr(self):
         checker = FormatChecker(formats=())


### PR DESCRIPTION
## What

Fixes #1511 — the `duration` format checker no longer crashes with an uncaught `decimal.Overflow` on strings whose amounts exceed `Decimal`'s context limits; they are reported as invalid durations like any other malformed instance.

## Why

`isoduration.parse_duration` builds each component amount with `Decimal(...)`. For an exponent past the context's `Emax` — e.g. `P1E1000000D` — or a plain digit run longer than 999999, `Decimal` raises `decimal.Overflow`, which is **not** a subclass of the checker's declared `isoduration.DurationParsingException`. The exception escapes `FormatChecker.check` uncaught and propagates out of `iter_errors`/`validate`:

```python
>>> v = Draft202012Validator({"format": "duration"}, format_checker=FormatChecker())
>>> list(v.iter_errors("P1E1000000D"))
# decimal.Overflow: [<class 'decimal.Overflow'>]  -- uncaught
```

The boundary is exact: `P1E999999D` is accepted, `P1E1000000D` overflows. The same bug is reachable without an exponent via a long digit run (`"P" + "9" * 1000000 + "D"`).

## How

`decimal.Overflow` is an `ArithmeticError`, so the checker's `raises` tuple is broadened to `(isoduration.DurationParsingException, ArithmeticError)` — the same idiom sibling checkers already use (e.g. `raises=(idna.IDNAError, UnicodeError)`, and the pattern proposed in #1526). `FormatChecker.check` then wraps it into a `FormatError` and the instance is reported as invalid.

## Tests

Added `TestFormatChecker.test_it_rejects_durations_that_overflow_decimal` (skipped when the optional `isoduration` dependency is not installed):
- `P1E1000000D` and the 1M-digit-run variant both raise `FormatError` (both crash with `decimal.Overflow` before the fix).
- `P1Y2M3DT4H5M6S` is still accepted.

Full test suite passes (497 tests). Added a CHANGELOG entry.

🤖 Generated with Codebuff
