### PR TITLE
Fix ErrorTree.__getitem__ mutating the tree on error-free access

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -321,12 +321,17 @@ class ErrorTree:
 
     def __init__(self, errors: Iterable[ValidationError] = ()):
         self.errors: MutableMapping[str, ValidationError] = {}
-        self._contents: Mapping[str, ErrorTree] = defaultdict(self.__class__)
+        self._contents: MutableMapping[str, ErrorTree] = defaultdict(
+            self.__class__,
+        )
 
         for error in errors:
             container = self
             for element in error.path:
-                container = container[element]
+                # Populate `_contents` directly (bypassing `__getitem__`)
+                # so that constructing the tree is the only thing allowed
+                # to auto-vivify entries in it.
+                container = container._contents[element]
             container.errors[error.validator] = error
 
             container._instance = error.instance
@@ -346,9 +351,14 @@ class ErrorTree:
         by ``instance.__getitem__`` will be propagated (usually this is
         some subclass of `LookupError`.
         """
-        if self._instance is not _unset and index not in self:
+        if index in self._contents:
+            return self._contents[index]
+        if self._instance is not _unset:
             self._instance[index]
-        return self._contents[index]
+        # `index` has no errors of its own -- return an empty tree for
+        # it without recording it in `_contents`, so that querying an
+        # error-free index does not change `__contains__`/`__iter__`.
+        return self.__class__()
 
     def __setitem__(self, index: str | int, value: ErrorTree):
         """

--- a/jsonschema/tests/test_exceptions.py
+++ b/jsonschema/tests/test_exceptions.py
@@ -476,6 +476,33 @@ class TestErrorTree(TestCase):
         tree = exceptions.ErrorTree([e1, e2])
         self.assertEqual(set(tree), {"bar", "foobar"})
 
+    def test_getitem_of_an_error_free_index_does_not_mutate_the_tree(self):
+        """
+        Accessing a valid index that has no errors of its own returns
+        an (empty) subtree, but must not cause that index to start
+        being reported by `__contains__` / `__iter__` / `total_errors`,
+        since it never actually had any errors.
+
+        See https://github.com/python-jsonschema/jsonschema/issues/1328
+        """
+        error = exceptions.ValidationError(
+            "a bar message", validator="foo", instance=["spam", "eggs"],
+            path=["bar", 0],
+        )
+        tree = exceptions.ErrorTree([error])["bar"]
+
+        self.assertEqual(list(tree), [0])
+        self.assertIn(0, tree)
+        self.assertNotIn(1, tree)
+        self.assertEqual(tree.total_errors, 1)
+
+        subtree = tree[1]
+
+        self.assertIsInstance(subtree, exceptions.ErrorTree)
+        self.assertEqual(list(tree), [0])
+        self.assertNotIn(1, tree)
+        self.assertEqual(tree.total_errors, 1)
+
     def test_repr_single(self):
         error = exceptions.ValidationError(
             "1",


### PR DESCRIPTION
## Summary

`ErrorTree.__contains__`/`__iter__` change their results after a read-only `ErrorTree.__getitem__` access on an index that had no errors, contradicting the documented contract ("Check whether `instance[index]` has any errors").

```python
from jsonschema import Draft202012Validator
from jsonschema.exceptions import ErrorTree

schema = {
    "type" : "array",
    "items" : {"type" : "number", "enum" : [1, 2, 3]},
    "minItems" : 3,
}
instance = ["spam", 2]

v = Draft202012Validator(schema)
tree = ErrorTree(v.iter_errors(instance))

list(tree)      # [0]      -- correct
1 in tree        # False    -- correct

tree[1]           # accessing the error-free index 1

list(tree)       # [0, 1]   -- wrong, 1 has no errors
1 in tree        # True     -- wrong
```

## Root cause

`ErrorTree._contents` is a `defaultdict(ErrorTree)`. `__getitem__` did `return self._contents[index]` directly -- and on a `defaultdict`, merely *reading* a missing key inserts it. So a read-only lookup for an error-free (but otherwise valid) index permanently adds that index to `_contents`, which is exactly what `__contains__`/`__iter__`/`total_errors` check.

## Fix

`__init__` (tree construction) is the only place that should auto-vivify entries, since it's recording real error paths -- so it now populates `_contents` directly (`container._contents[element]`) instead of going through the public `__getitem__`.

`__getitem__` no longer touches `_contents` for a miss: it validates the index against `self._instance` (still propagating `LookupError` for genuinely invalid indices, per the existing docstring/tests) and returns a fresh, unstored `ErrorTree()` for an index with no recorded errors, so `_contents` -- and therefore `__contains__`/`__iter__`/`total_errors`/`__len__`/`__repr__`, which all read `_contents` -- stay accurate.

## Testing

- Added `test_getitem_of_an_error_free_index_does_not_mutate_the_tree` to `jsonschema/tests/test_exceptions.py`, reproducing the exact scenario from the issue and asserting `list(tree)`/`in`/`total_errors` are unchanged before and after accessing the error-free index.
- Full suite: `jsonschema/tests/`: 8281 passed, 232 skipped (unrelated/environment-gated), 0 failed.
- Reverting only `jsonschema/exceptions.py` (keeping the new test) reproduces the exact reported bug: `AssertionError: Lists differ: [0, 1] != [0]`.
- `ruff check` clean on both changed files.

Fixes #1328
