### PR TITLE
fix: exclude tests and benchmarks from wheels

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from zipfile import ZipFile
 import os
 
 import nox
@@ -48,7 +49,10 @@ def tests(session, installable):
     """
     Run the test suite with a corresponding Python version.
     """
-    env = dict(JSON_SCHEMA_TEST_SUITE=str(ROOT / "json"))
+    env = dict(
+        JSON_SCHEMA_TEST_SUITE=str(ROOT / "json"),
+        PYTHONPATH=str(ROOT),
+    )
 
     session.install("--group=test", installable)
 
@@ -109,6 +113,16 @@ def build(session):
             "--outdir",
             tmpdir,
         )
+        wheel, = Path(tmpdir).glob("*.whl")
+        with ZipFile(wheel) as archive:
+            bundled = [
+                path for path in archive.namelist()
+                if path.startswith(
+                    ("jsonschema/benchmarks/", "jsonschema/tests/"),
+                )
+            ]
+        if bundled:
+            session.error(f"Wheel contains test or benchmark files: {bundled}")
         session.run("twine", "check", "--strict", tmpdir + "/*")
         session.run(
             "python", "-m", "docutils", "--strict", CHANGELOG, os.devnull,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.build.targets.wheel]
+exclude = [
+  "jsonschema/benchmarks",
+  "jsonschema/tests",
+]
+
 [project]
 name = "jsonschema"
 description = "An implementation of JSON Schema validation for Python"


### PR DESCRIPTION
## What Problem This Solves

The wheel currently bundles the test suite and benchmarks even though neither is needed at runtime. This adds unnecessary files and size to installed distributions.

Fixes python-jsonschema/jsonschema#1552.

## Why This Change Was Made

The Hatch wheel target excludes jsonschema/tests and jsonschema/benchmarks while the source distribution continues to include both. The build session inspects the generated wheel and fails if either directory is bundled again. Test sessions explicitly load the source tree so removing tests from installed wheels does not suppress test discovery.

## User Impact

Future wheels contain only runtime package files, producing a smaller, cleaner installation without changing library behavior or source distributions.

## Evidence

- All three Python 3.14 test environments passed: 8,512 tests per environment
- Ruff passed
- Distribution build, wheel-content assertion, Twine strict validation, and changelog validation passed
- Verified the source distribution still includes tests and benchmarks