### PR TITLE
Widen regex format checker's exception handling to cover ValueError and RecursionError

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -413,7 +413,7 @@ with suppress(ImportError):
         return is_datetime("1970-01-01T" + instance)
 
 
-@_checks_drafts(name="regex", raises=re.error)
+@_checks_drafts(name="regex", raises=(re.error, ValueError, RecursionError))
 def is_regex(instance: object) -> bool:
     if not isinstance(instance, str):
         return True

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -80,6 +80,28 @@ class TestFormatChecker(TestCase):
         with self.assertRaises(FormatError):
             checker.check(instance="not-an-ipv4", format="ipv4")
 
+    def test_regex_format_rejects_incompatible_inline_flags(self):
+        # re.compile raises ValueError (not re.error) for two incompatible
+        # inline flag groups, e.g. re.compile("(?u)(?a)"). Previously this
+        # propagated uncaught since the "regex" checker only declared
+        # raises=re.error. See GH #1558.
+        checker = FormatChecker()
+        self.assertFalse(checker.conforms("(?u)(?a)", "regex"))
+        self.assertFalse(checker.conforms("(?a)(?u)", "regex"))
+
+    def test_regex_format_rejects_deeply_nested_patterns(self):
+        # re.compile raises RecursionError (not re.error) for patterns
+        # whose nesting exceeds the C stack limit while parsing, e.g. many
+        # unclosed groups. Previously this propagated uncaught. See GH
+        # #1538.
+        checker = FormatChecker()
+        self.assertFalse(checker.conforms("(" * 2000, "regex"))
+
+    def test_regex_format_still_accepts_valid_and_rejects_invalid(self):
+        checker = FormatChecker()
+        self.assertTrue(checker.conforms("valid.*regex", "regex"))
+        self.assertFalse(checker.conforms("[unterminated", "regex"))
+
     def test_repr(self):
         checker = FormatChecker(formats=())
         checker.checks("foo")(lambda thing: True)  # pragma: no cover


### PR DESCRIPTION
Fixes #1558. Also fixes #1538.

## Problem

The `regex` format checker is declared with `raises=re.error`:

```python
@_checks_drafts(name="regex", raises=re.error)
def is_regex(instance: object) -> bool:
    if not isinstance(instance, str):
        return True
    return bool(re.compile(instance))
```

`FormatChecker.check`/`conforms` only convert the *declared* exception(s) into a `FormatError`/`False`. But `re.compile` raises several exception types that are **not** `re.error` subclasses for various malformed patterns:

- `ValueError`, when a pattern sets two incompatible inline flags, e.g. `re.compile("(?u)(?a)")` (#1558)
- `RecursionError`, when pattern nesting exceeds the C stack limit while parsing, e.g. `re.compile("(" * 2000)` (#1538)

In both cases the exception escapes uncaught instead of being reported as an invalid regex, unlike every other malformed pattern (which raises `re.error` and is correctly caught).

```python
>>> from jsonschema import FormatChecker
>>> fc = FormatChecker()
>>> fc.conforms("[unterminated", "regex")   # re.error -> caught, returns False
False
>>> fc.conforms("(?u)(?a)", "regex")        # ValueError -> escapes uncaught
Traceback (most recent call last):
  ...
ValueError: ASCII and UNICODE flags are incompatible
```

## Fix

Widen the declared exception tuple to `raises=(re.error, ValueError, RecursionError)`, matching the pattern already used by sibling checkers that declare multiple exception types (e.g. `idn-hostname`'s `raises=(idna.IDNAError, UnicodeError)`, `css2.1-color`'s `raises=(ValueError, TypeError)`).

## Note on #1526

There's also an open PR (#1526) proposing to add `OverflowError` to this same tuple for a third case (oversized repeat counts, e.g. `re.compile("a{99999999999999}")`, also not an `re.error` subclass). I deliberately left that case out of this PR so as not to duplicate #1526's scope. Happy to rebase this PR to also include `OverflowError` if a maintainer would prefer one consolidated fix over two separate PRs -- the issue reporter for #1558 noted all three share the same root cause.

## Testing

Added three tests to `TestFormatChecker`: `test_regex_format_rejects_incompatible_inline_flags`, `test_regex_format_rejects_deeply_nested_patterns`, and a baseline sanity check `test_regex_format_still_accepts_valid_and_rejects_invalid`.

- Reverted the one-line fix locally and confirmed the two new "rejects" tests fail with the exact uncaught `ValueError`/`RecursionError` described in #1558/#1538; restored the fix and confirmed all pass.
- Ran the full `jsonschema/tests/` suite against the change (excluding `test_exceptions.py` and `test_jsonschema_test_suite.py`, which fail for unrelated, pre-existing environment reasons -- a missing `jsonpath_ng` dependency and a missing JSON-Schema-Test-Suite submodule checkout respectively, confirmed unrelated by reproducing the identical failures against an unmodified checkout): 425 passed, no regressions. With the three new tests added: 427 passed total (11/11 in `test_format.py`).