### PR TITLE
Treat incompatible regex inline flags as an invalid format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+v4.27.0
+=======
+
+* Catch ``ValueError`` from ``re.compile`` in the ``regex`` format checker so
+  incompatible inline flags (e.g. ``(?u)(?a)``) are reported as invalid rather
+  than crashing (#1558).
+
 v4.26.0
 =======
 

--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -413,7 +413,7 @@ with suppress(ImportError):
         return is_datetime("1970-01-01T" + instance)
 
 
-@_checks_drafts(name="regex", raises=re.error)
+@_checks_drafts(name="regex", raises=(re.error, ValueError))
 def is_regex(instance: object) -> bool:
     if not isinstance(instance, str):
         return True

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -71,6 +71,20 @@ class TestFormatChecker(TestCase):
         self.assertIs(cm.exception.cause, BOOM)
         self.assertIs(cm.exception.__cause__, BOOM)
 
+    def test_regex_format_incompatible_inline_flags_are_invalid(self):
+        """
+        ``re.compile`` raises ``ValueError`` (not ``re.error``) when a
+        pattern sets incompatible inline flags in separate groups, e.g.
+        ``(?u)(?a)``. That must be reported as an invalid regex rather
+        than escaping as an uncaught exception.
+        """
+        checker = FormatChecker()
+        self.assertFalse(checker.conforms("(?u)(?a)", "regex"))
+        self.assertFalse(checker.conforms("(?a)(?u)", "regex"))
+        with self.assertRaises(FormatError) as cm:
+            checker.check("(?u)(?a)", "regex")
+        self.assertIsInstance(cm.exception.cause, ValueError)
+
     def test_format_checkers_come_with_defaults(self):
         # This is bad :/ but relied upon.
         # The docs for quite awhile recommended people do things like


### PR DESCRIPTION
Fixes #1558.

The `regex` format checker is registered with `raises=re.error`. `re.compile` raises `ValueError` (not an `re.error` subclass) when a pattern sets incompatible inline flags in separate groups, for example `(?u)(?a)`.

That exception escaped `FormatChecker.check`, so format validation crashed instead of reporting the string as invalid.

This adds `ValueError` to the declared exceptions. `FormatChecker.conforms("(?u)(?a)", "regex")` now returns `False`, matching unterminated patterns that already raise `re.error`.
