### PR TITLE
Fix a docs linkcheck failure

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,7 @@ def entire_domain(host):
 linkcheck_ignore = [
     entire_domain("zenodo.org"),
     entire_domain("img.shields.io"),
+    entire_domain("json-schema.slack.com"),
     "https://github.com/python-jsonschema/jsonschema/actions",
     "https://github.com/python-jsonschema/jsonschema/workflows/CI/badge.svg",
 ]


### PR DESCRIPTION
It looks like Slack's site is valid but returning HTTP 403 errors.

This adds `json-schema.slack.com` to the linkcheck's ignore list.