### PR TITLE
Report regexes with conflicting inline flags as invalid, not an error

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -413,7 +413,7 @@ with suppress(ImportError):
         return is_datetime("1970-01-01T" + instance)
 
 
-@_checks_drafts(name="regex", raises=re.error)
+@_checks_drafts(name="regex", raises=(re.error, ValueError))
 def is_regex(instance: object) -> bool:
     if not isinstance(instance, str):
         return True

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -60,6 +60,24 @@ class TestFormatChecker(TestCase):
         with self.assertRaises(type(BANG)):
             checker.check(instance="bang", format="boom")
 
+    def test_regex_conflicting_inline_flags_report_invalid_not_error(self):
+        # re.compile raises ValueError (not an re.error subclass) for
+        # incompatible inline flags in separate groups, which must surface
+        # as a FormatError rather than escape the checker (#1558).
+        checker = FormatChecker(formats=["regex"])
+
+        with self.assertRaises(FormatError):
+            checker.check("(?u)(?a)", "regex")
+
+        self.assertFalse(checker.conforms("(?u)(?a)", "regex"))
+        self.assertFalse(checker.conforms("(?a)(?u)", "regex"))
+
+        # The single-group form was already correctly invalid.
+        self.assertFalse(checker.conforms("(?ua)", "regex"))
+        # And a plain re.error still reports invalid rather than raising.
+        self.assertFalse(checker.conforms("[unterminated", "regex"))
+        self.assertTrue(checker.conforms("a+b?", "regex"))
+
     def test_format_error_causes_become_validation_error_causes(self):
         checker = FormatChecker()
         checker.checks("boom", raises=ValueError)(boom)


### PR DESCRIPTION
Fixes #1558.

## Root cause

`re.compile` raises `ValueError` — which is **not** an `re.error` subclass — when a pattern sets incompatible inline flags in separate groups (`"(?u)(?a)"` or `"(?a)(?u)"`). The `regex` format checker declared `raises=re.error` only, so the exception escaped `FormatChecker.check` and crashed the caller instead of reporting the string as an invalid regex:

```python
fc.conforms("[unterminated", "regex")  # False — re.error, caught
fc.conforms("(?u)(?a)", "regex")       # ValueError: ASCII and UNICODE flags are incompatible
```

The single-group form (`"(?ua)"`) fails compilation with `re.error` and was already reported correctly; only the two-group form escaped.

## Fix

Declare `raises=(re.error, ValueError)` on `is_regex`, so the conflicting-flags `ValueError` becomes a `FormatError` with the original exception as its `cause`, exactly like any other invalid regex.

The related-but-distinct exception types from #1526 (`OverflowError` on an oversized repeat) and #1538 (`RecursionError` on deep nesting) are left to their own issues — this PR only widens the declaration for the `ValueError` family demonstrated in #1558.

## Test

`test_regex_conflicting_inline_flags_report_invalid_not_error` in `jsonschema/tests/test_format.py`: both flag orders raise `FormatError` / conform `False`, the single-group form and a plain `re.error` case still report invalid, and a valid pattern still passes.

Differential: the new test errors with the escaped `ValueError` on `main` and passes with the change. Full suite: `python -m unittest discover jsonschema.tests` — 8455 tests, only a pre-existing local `test_exceptions` import error unrelated to this change (also present on stashed `main`).
