### PR TITLE
Report deeply nested regexes as invalid, not a RecursionError

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -413,7 +413,7 @@ with suppress(ImportError):
         return is_datetime("1970-01-01T" + instance)
 
 
-@_checks_drafts(name="regex", raises=re.error)
+@_checks_drafts(name="regex", raises=(re.error, ValueError, RecursionError))
 def is_regex(instance: object) -> bool:
     if not isinstance(instance, str):
         return True

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from jsonschema import FormatChecker, ValidationError
 from jsonschema.exceptions import FormatError
-from jsonschema.validators import Draft202012Validator, Draft4Validator
+from jsonschema.validators import Draft4Validator, Draft202012Validator
 
 BOOM = ValueError("Boom!")
 BANG = ZeroDivisionError("Bang!")

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from jsonschema import FormatChecker, ValidationError
 from jsonschema.exceptions import FormatError
-from jsonschema.validators import Draft4Validator
+from jsonschema.validators import Draft202012Validator, Draft4Validator
 
 BOOM = ValueError("Boom!")
 BANG = ZeroDivisionError("Bang!")
@@ -70,6 +70,24 @@ class TestFormatChecker(TestCase):
 
         self.assertIs(cm.exception.cause, BOOM)
         self.assertIs(cm.exception.__cause__, BOOM)
+
+    def test_deeply_nested_regex_reports_invalid_not_recursion_error(self):
+        # re.compile raises RecursionError (not an re.error subclass) when
+        # pattern nesting exceeds the recursion limit, which must surface
+        # as a FormatError / validation error rather than propagate (#1538).
+        checker = FormatChecker(formats=["regex"])
+        validator = Draft202012Validator(
+            {"format": "regex"}, format_checker=checker,
+        )
+        nested = "(" * 500
+
+        with self.assertRaises(FormatError):
+            checker.check(nested, "regex")
+
+        self.assertFalse(checker.conforms(nested, "regex"))
+        errors = list(validator.iter_errors(nested))
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0].cause, RecursionError)
 
     def test_format_checkers_come_with_defaults(self):
         # This is bad :/ but relied upon.


### PR DESCRIPTION
Fixes #1538.

## Root cause

`re.compile` raises `RecursionError` — not an `re.error` subclass — when a pattern's nesting exceeds the recursion limit (`"(" * 500`). The `regex` format checker declared `raises=re.error` only, so the exception escaped `FormatChecker.check` and propagated out of `iter_errors` instead of reporting the instance as an invalid regex:

```python
v = Draft202012Validator({"format": "regex"}, format_checker=FormatChecker())
list(v.iter_errors("(" * 500))   # RecursionError: maximum recursion depth exceeded
```

## Fix

Declare `RecursionError` alongside `re.error` in the checker's `raises`, so it converts to a `FormatError` whose `cause` is the original `RecursionError` — the same family as the conflicting-inline-flags `ValueError` fix. The pattern genuinely cannot compile on this interpreter, so "invalid regex" is the honest verdict. (#1526's `OverflowError` remains a separate issue.)

## Test

`test_deeply_nested_regex_reports_invalid_not_recursion_error` in `jsonschema/tests/test_format.py`: the exact `"(" * 500` reproduction from the issue raises `FormatError` from `check`, conforms `False`, and `iter_errors` yields exactly one validation error whose `cause` is the `RecursionError`.

Differential: the new test errors with the escaped `RecursionError` on `main` and passes with the change. Full suite: 8456 tests with only the pre-existing local `test_exceptions` import error (environmental, also present on stashed `main`).
