### PR TITLE
Report regexes with oversized repeat counts as invalid, not an OverflowError

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -413,7 +413,7 @@ with suppress(ImportError):
         return is_datetime("1970-01-01T" + instance)
 
 
-@_checks_drafts(name="regex", raises=re.error)
+@_checks_drafts(name="regex", raises=(re.error, OverflowError))
 def is_regex(instance: object) -> bool:
     if not isinstance(instance, str):
         return True

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from jsonschema import FormatChecker, ValidationError
 from jsonschema.exceptions import FormatError
-from jsonschema.validators import Draft202012Validator, Draft4Validator
+from jsonschema.validators import Draft4Validator, Draft202012Validator
 
 BOOM = ValueError("Boom!")
 BANG = ZeroDivisionError("Bang!")

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from jsonschema import FormatChecker, ValidationError
 from jsonschema.exceptions import FormatError
-from jsonschema.validators import Draft4Validator
+from jsonschema.validators import Draft202012Validator, Draft4Validator
 
 BOOM = ValueError("Boom!")
 BANG = ZeroDivisionError("Bang!")
@@ -70,6 +70,27 @@ class TestFormatChecker(TestCase):
 
         self.assertIs(cm.exception.cause, BOOM)
         self.assertIs(cm.exception.__cause__, BOOM)
+
+    def test_oversized_repeat_regex_reports_invalid_not_overflow(self):
+        # re.compile raises OverflowError (not an re.error subclass) when a
+        # repetition count is too large, which must surface as a FormatError
+        # rather than escape the checker (#1526).
+        checker = FormatChecker(formats=["regex"])
+        validator = Draft202012Validator(
+            {"format": "regex"}, format_checker=checker,
+        )
+        pattern = "a{99999999999999}"
+
+        with self.assertRaises(FormatError):
+            checker.check(pattern, "regex")
+
+        self.assertFalse(checker.conforms(pattern, "regex"))
+        errors = list(validator.iter_errors(pattern))
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0].cause, OverflowError)
+
+        # A sane bounded repeat still compiles and conforms.
+        self.assertTrue(checker.conforms("a{2,4}", "regex"))
 
     def test_format_checkers_come_with_defaults(self):
         # This is bad :/ but relied upon.


### PR DESCRIPTION
Fixes #1526.

## Root cause

`re.compile` raises `OverflowError` — not an `re.error` subclass — when a repetition count is too large (`"a{99999999999999}"`). The `regex` format checker declared `raises=re.error` only, so the exception escaped `FormatChecker.check` and propagated out of `iter_errors`/`validate` instead of reporting the string as an invalid regex:

```python
fc.conforms("[unterminated", "regex")        # False — re.error, caught
fc.conforms("a{99999999999999}", "regex")    # OverflowError: the repetition number is too large
```

## Fix

Declare `OverflowError` alongside `re.error` (`raises=(re.error, OverflowError)`), so it converts to a `FormatError` whose `cause` is the original `OverflowError`. The pattern genuinely cannot compile, so "invalid regex" is the honest verdict.

This is the third member of the exception-family cluster: #1558 (`ValueError`, conflicting inline flags) and #1538 (`RecursionError`, deep nesting) are the siblings — each is filed as its own issue, so this PR touches only the `OverflowError` arm and will trivially rebase if a sibling lands first.

## Test

`test_oversized_repeat_regex_reports_invalid_not_overflow` in `jsonschema/tests/test_format.py`: the issue's exact pattern raises `FormatError` from `check`, conforms `False`, and `iter_errors` yields exactly one validation error whose `cause` is the `OverflowError`; a sane bounded repeat (`a{2,4}`) still conforms.

Differential: the new test errors with the escaped `OverflowError` on `main` and passes with the change. Full suite: 8456 tests with only the pre-existing local `test_exceptions` import error (environmental, also present on unmodified `main`).